### PR TITLE
Refactor consensus Engine.Seal to return sealed block and adapt miners/engines

### DIFF
--- a/cmd/cypher/retesteth.go
+++ b/cmd/cypher/retesteth.go
@@ -273,15 +273,13 @@ func (e *NoRewardEngine) VerifyCandidate(chain types.KeyChainReader, candidate *
 	return nil
 }
 
-/*
-func (e *NoRewardEngine) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
-	return e.inner.Seal(chain, block, results, stop)
+func (e *NoRewardEngine) Seal(chain consensus.ChainHeaderReader, block *types.Block, stop <-chan struct{}) (*types.Block, error) {
+	return e.inner.Seal(chain, block, stop)
 }
 
 func (e *NoRewardEngine) SealHash(header *types.Header) common.Hash {
 	return e.inner.SealHash(header)
 }
-*/
 
 func (e *NoRewardEngine) CalcDifficulty(chain consensus.ChainHeaderReader, time uint64, parent *types.Header) *big.Int {
 	return e.inner.CalcDifficulty(chain, time, parent)

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -582,18 +582,18 @@ func (c *Clique) Authorize(signer common.Address, signFn SignerFn) {
 
 // Seal implements consensus.Engine, attempting to create a sealed block using
 // the local signing credentials.
-func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
+func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, stop <-chan struct{}) (*types.Block, error) {
 	header := block.Header()
 
 	// Sealing the genesis block is not supported
 	number := header.Number.Uint64()
 	if number == 0 {
-		return errUnknownBlock
+		return nil, errUnknownBlock
 	}
 	// For 0-period chains, refuse to seal empty blocks (no reward but would spin sealing)
 	if c.config.Period == 0 && len(block.Transactions()) == 0 {
 		log.Info("Sealing paused, waiting for transactions")
-		return nil
+		return nil, nil
 	}
 	// Don't hold the signer fields for the entire sealing procedure
 	c.lock.RLock()
@@ -603,21 +603,21 @@ func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 	// Bail out if we're unauthorized to sign a block
 	snap, err := c.snapshot(chain, number-1, header.ParentHash, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if _, authorized := snap.Signers[signer]; !authorized {
-		return errUnauthorizedSigner
+		return nil, errUnauthorizedSigner
 	}
 	// If we're amongst the recent signers, wait for the next block
 	for seen, recent := range snap.Recents {
 		if recent == signer {
 			// Signer is among recents, only wait if the current block doesn't shift it out
-			if limit := uint64(len(snap.Signers)/2 + 1); number < limit || seen > number-limit {
-				log.Info("Signed recently, must wait for others")
-				return nil
+				if limit := uint64(len(snap.Signers)/2 + 1); number < limit || seen > number-limit {
+					log.Info("Signed recently, must wait for others")
+					return nil, nil
+				}
 			}
 		}
-	}
 	// Sweet, the protocol permits us to sign the block, wait for our time
 	delay := time.Unix(int64(header.Time), 0).Sub(time.Now()) // nolint: gosimple
 	if header.Difficulty.Cmp(diffNoTurn) == 0 {
@@ -630,26 +630,18 @@ func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, res
 	// Sign all the things!
 	sighash, err := signFn(accounts.Account{Address: signer}, accounts.MimetypeClique, CliqueRLP(header))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	copy(header.Extra[len(header.Extra)-extraSeal:], sighash)
 	// Wait until sealing is terminated or delay timeout.
 	log.Trace("Waiting for slot to sign and propagate", "delay", common.PrettyDuration(delay))
-	go func() {
-		select {
-		case <-stop:
-			return
-		case <-time.After(delay):
-		}
+	select {
+	case <-stop:
+		return nil, nil
+	case <-time.After(delay):
+	}
 
-		select {
-		case results <- block.WithSeal(header):
-		default:
-			log.Warn("Sealing result is not read by miner", "sealhash", SealHash(header))
-		}
-	}()
-
-	return nil
+	return block.WithSeal(header), nil
 }
 
 // CalcDifficulty is the difficulty adjustment algorithm. It returns the difficulty

--- a/consensus/consensus_interface.go
+++ b/consensus/consensus_interface.go
@@ -70,7 +70,9 @@ type Engine interface {
 	FinalizeAndAssemble(chain ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction,
 		uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error)
 
-	//Seal(chain ChainReader, block *types.Block, stop <-chan struct{}) (*types.Block, error)
+	// Seal generates a new block for the given input block with the local miner's
+	// seal placed on top.
+	Seal(chain ChainHeaderReader, block *types.Block, stop <-chan struct{}) (*types.Block, error)
 
 	// SealCandidate generates a new candidate with the local miner's seal place on top.
 	SealCandidate(candidate *types.Candidate, stop <-chan struct{}) (*types.Candidate, error)

--- a/consensus/ethash/colossus_test.go
+++ b/consensus/ethash/colossus_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/cypherium/cypher/common"
+	"github.com/cypherium/cypher/consensus"
 	"github.com/cypherium/cypher/core/types"
 	"golang.org/x/crypto/sha3"
 )
@@ -211,5 +212,54 @@ func TestColossusGoldenVectors(t *testing.T) {
 		if !bytes.Equal(mix, fullMix) || !bytes.Equal(res, fullRes) {
 			t.Fatalf("golden vector mismatch for epoch=%d nonce=%d", v.epoch, v.nonce)
 		}
+	}
+}
+
+func TestEngineSealNormalBlockViaInterface(t *testing.T) {
+	eth := NewTester()
+	defer eth.Close()
+	eth.SetThreads(1)
+
+	var engine consensus.Engine = eth
+	header := testHeader()
+	header.Number = big.NewInt(1)
+	header.Difficulty = big.NewInt(1)
+	header.MixDigest = common.Hash{}
+	header.Nonce = types.BlockNonce{}
+	header.BlockType = types.Normal_Block
+
+	block := types.NewBlock(header, nil, nil, nil, nil)
+	stop := make(chan struct{})
+	sealed, err := engine.Seal(nil, block, stop)
+	if err != nil {
+		t.Fatalf("engine seal failed: %v", err)
+	}
+	if sealed == nil {
+		t.Fatal("engine returned nil sealed block")
+	}
+	if sealed.Header().MixDigest == (common.Hash{}) {
+		t.Fatal("sealed block mix digest is empty")
+	}
+	if err := eth.VerifySeal(nil, sealed.Header()); err != nil {
+		t.Fatalf("sealed block failed VerifySeal: %v", err)
+	}
+}
+
+func TestSealCandidateFlowUnchanged(t *testing.T) {
+	eth := NewFaker()
+	defer eth.Close()
+
+	candidate := types.NewCandidate(common.HexToHash("0x1"), big.NewInt(1), 1, 0, nil, []byte{127, 0, 0, 1}, "pk", "cb", 30303)
+	stop := make(chan struct{})
+
+	sealed, err := eth.SealCandidate(candidate, stop)
+	if err != nil {
+		t.Fatalf("SealCandidate failed: %v", err)
+	}
+	if sealed == nil {
+		t.Fatal("SealCandidate returned nil")
+	}
+	if err := eth.VerifyCandidate(nil, sealed); err != nil {
+		t.Fatalf("VerifyCandidate failed: %v", err)
 	}
 }

--- a/consensus/ethash/sealer.go
+++ b/consensus/ethash/sealer.go
@@ -28,11 +28,29 @@ import (
 	"time"
 
 	"github.com/cypherium/cypher/common"
+	"github.com/cypherium/cypher/consensus"
 	"github.com/cypherium/cypher/core/types"
 	"github.com/cypherium/cypher/log"
 )
 
 var errSealingStopped = errors.New("sealing stopped")
+
+// Seal implements consensus.Engine, attempting to find a valid nonce for normal blocks.
+func (ethash *Ethash) Seal(chain consensus.ChainHeaderReader, block *types.Block, stop <-chan struct{}) (*types.Block, error) {
+	_ = chain
+	if block == nil {
+		return nil, errors.New("nil block")
+	}
+	header := block.Header()
+	if header.BlockType != types.Normal_Block {
+		return nil, errors.New("seal only supports normal block type")
+	}
+	sealed, err := ethash.SealHeader(header, stop)
+	if err != nil {
+		return nil, err
+	}
+	return block.WithSeal(sealed), nil
+}
 
 // SealCandidate implements pow.Engine, attempting to find a nonce that satisfies
 // the candidate's difficulty requirements.

--- a/miner/agent.go
+++ b/miner/agent.go
@@ -103,10 +103,21 @@ out:
 
 func (self *CpuAgent) mine(work *Work, stop <-chan struct{}) {
 	log.Info("CpuAgent.mine")
+	if work.block != nil {
+		if result, err := self.engine.Seal(nil, work.block, stop); result != nil {
+			self.returnCh <- &Result{Work: work, Block: result}
+		} else {
+			if err != nil {
+				log.Warn("Block sealing failed", "err", err)
+			}
+			self.returnCh <- nil
+		}
+		return
+	}
 	if result, err := self.engine.SealCandidate(work.candidate, stop); result != nil {
 		log.Info("Successfully sealed new candidate", "nonce", work.candidate.KeyCandidate.Nonce.Uint64(), "mixdigest", work.candidate.KeyCandidate.MixDigest.Hex())
 
-		self.returnCh <- &Result{work, result}
+		self.returnCh <- &Result{Work: work, Candidate: result}
 	} else {
 		if err != nil {
 			log.Warn("Candidate sealing failed", "err", err)

--- a/miner/remote_agent.go
+++ b/miner/remote_agent.go
@@ -156,7 +156,7 @@ func (a *RemoteAgent) SubmitWork(nonce types.BlockNonce, mixDigest, hash common.
 	}
 
 	// Solutions seems to be valid, return to the miner and notify acceptance
-	a.returnCh <- &Result{work, candidate}
+	a.returnCh <- &Result{Work: work, Candidate: candidate}
 	delete(a.work, hash)
 
 	return true

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -45,6 +45,7 @@ type Work struct {
 	signer types.Signer
 
 	keyBlock  *types.KeyBlock // todo: should be the latest key block header
+	block     *types.Block
 	candidate *types.Candidate
 
 	createdAt time.Time
@@ -52,6 +53,7 @@ type Work struct {
 
 type Result struct {
 	Work      *Work
+	Block     *types.Block
 	Candidate *types.Candidate
 }
 
@@ -227,7 +229,10 @@ func (self *worker) wait() {
 				continue
 			}
 
-			candidate := result.Candidate
+				if result.Candidate == nil {
+					continue
+				}
+				candidate := result.Candidate
 
 			if err := self.engine.VerifyCandidate(self.chain, candidate); err != nil {
 				log.Error("Fail to verify sealed candidate", "err", err)


### PR DESCRIPTION
### Motivation

- Unify the `consensus.Engine` sealing API to return a sealed block directly instead of pushing results over a channel, simplifying control flow and error handling.
- Update consensus engine implementations and miner code to support both block sealing and existing candidate sealing flows consistently.
- Ensure ethash engine remains backwards compatible for candidate sealing while exposing block sealing via the new interface.

### Description

- Changed the `consensus.Engine.Seal` signature to `Seal(chain ChainHeaderReader, block *types.Block, stop <-chan struct{}) (*types.Block, error)` in `consensus/consensus_interface.go` and adjusted comments accordingly.
- Updated Clique's `Seal` implementation to the new return-style API, removed use of a results channel, and updated control paths to return `(*types.Block, error)` (file `consensus/clique/clique.go`).
- Added an adapter `Seal` to Ethash that seals `types.Block` by delegating to `SealHeader`, while preserving `SealCandidate` for PoW candidate flows (files `consensus/ethash/sealer.go`, `consensus/ethash/colossus_test.go`).
- Updated miner internals to support both block and candidate sealing: added a `block` field to `Work`, extended `Result` to carry `Block` and `Candidate`, updated `CpuAgent.mine` to call `engine.Seal` for blocks and `engine.SealCandidate` for candidates, and adapted `RemoteAgent.SubmitWork` and worker `wait` logic for the new result shape (files `miner/agent.go`, `miner/remote_agent.go`, `miner/worker.go`).
- Small related changes in `cmd/cypher/retesteth.go` and `cmd/cypher/retesteth.go`'s NoRewardEngine to match the new `Seal` signature.
- Added tests `TestEngineSealNormalBlockViaInterface` and `TestSealCandidateFlowUnchanged` to `consensus/ethash/colossus_test.go` to verify block sealing via the interface and that candidate sealing behavior is unchanged.

### Testing

- Ran unit tests for the consensus packages, including the new ethash tests, with `go test ./consensus/...`; the tests completed and passed.
- Ran package tests covering miner components to ensure compilation and basic worker/agent flows; the tests completed and passed.
- The new tests `TestEngineSealNormalBlockViaInterface` and `TestSealCandidateFlowUnchanged` were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2fd05b7788330a5ed7820a3245b87)