### PR TITLE
ethash: implement ColossusHash-v1.1 for normal block PoW

### DIFF
--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -46,6 +46,19 @@ const (
 	datasetParents     = 256     // Number of parents of each dataset element
 	cacheRounds        = 3       // Number of rounds in cache production
 	loopAccesses       = 64      // Number of accesses in hashimoto loop
+
+	colossusPageBytes       = 512
+	colossusTileBytes       = 512
+	colossusScratchpadBytes = 8 * 1024 * 1024
+	colossusScratchpadWords = colossusScratchpadBytes / 4
+	colossusPageWords       = colossusPageBytes / 4
+	colossusTileWords       = colossusTileBytes / 4
+	colossusNumTiles        = colossusScratchpadBytes / colossusTileBytes
+	colossusRounds          = 64
+	colossusInternalPasses  = 4
+	colossusStateWords      = 16
+	colossusAccWords        = 8
+	colossusDomainTag       = "COLXH1"
 )
 
 // cacheSize returns the size of the ethash verification cache that belongs to a certain
@@ -399,6 +412,148 @@ func hashimotoFull(dataset []uint32, hash []byte, nonce uint64) ([]byte, []byte)
 		return dataset[offset : offset+hashWords]
 	}
 	return hashimoto(hash, nonce, uint64(len(dataset))*4, lookup)
+}
+
+func colossusEffectiveDatasetBytes(size uint64) uint64 {
+	return (size / colossusPageBytes) * colossusPageBytes
+}
+
+func colossusNumPages(size uint64) uint32 {
+	return uint32(colossusEffectiveDatasetBytes(size) / colossusPageBytes)
+}
+
+func colossusNonceLE(n uint64) [8]byte {
+	var out [8]byte
+	binary.LittleEndian.PutUint64(out[:], n)
+	return out
+}
+
+func colossusRotl32(v, bits uint32) uint32 {
+	return (v << (bits & 31)) | (v >> ((32 - bits) & 31))
+}
+
+func colossusSeedWords(seed []byte) [colossusStateWords]uint32 {
+	var out [colossusStateWords]uint32
+	for i := 0; i < colossusStateWords; i++ {
+		out[i] = binary.LittleEndian.Uint32(seed[i*4:])
+	}
+	return out
+}
+
+func colossusStateBytes(state *[colossusStateWords]uint32, acc *[colossusAccWords]uint32) []byte {
+	out := make([]byte, (colossusStateWords+colossusAccWords)*4)
+	for i := 0; i < colossusStateWords; i++ {
+		binary.LittleEndian.PutUint32(out[i*4:], state[i])
+	}
+	base := colossusStateWords * 4
+	for i := 0; i < colossusAccWords; i++ {
+		binary.LittleEndian.PutUint32(out[base+i*4:], acc[i])
+	}
+	return out
+}
+
+func colossusLookupPageFull(dataset []uint32, pageIndex uint32, out *[colossusPageWords]uint32) {
+	start := int(pageIndex) * colossusPageWords
+	copy(out[:], dataset[start:start+colossusPageWords])
+}
+
+func colossusLookupPageLight(cache []uint32, pageIndex uint32, keccak512 hasher, out *[colossusPageWords]uint32) {
+	baseItem := pageIndex * (colossusPageBytes / hashBytes)
+	for i := uint32(0); i < (colossusPageBytes / hashBytes); i++ {
+		item := generateDatasetItem(cache, baseItem+i, keccak512)
+		wordOffset := int(i) * hashWords
+		for w := 0; w < hashWords; w++ {
+			out[wordOffset+w] = binary.LittleEndian.Uint32(item[w*4:])
+		}
+	}
+}
+
+func colossusHashCore(numPages uint32, sealHash []byte, nonce uint64, pageLookup func(pageIndex uint32, out *[colossusPageWords]uint32)) ([]byte, []byte) {
+	nonceLE := colossusNonceLE(nonce)
+	seed := crypto.Keccak512([]byte(colossusDomainTag), sealHash, nonceLE[:])
+
+	state := colossusSeedWords(seed)
+	var acc [colossusAccWords]uint32
+	for i := 0; i < colossusAccWords; i++ {
+		acc[i] = state[i] ^ state[i+colossusAccWords]
+	}
+
+	scratchpad := make([]uint32, colossusScratchpadWords)
+	for k := uint32(0); k < colossusScratchpadWords; k++ {
+		idx := k % colossusStateWords
+		x := state[idx]
+		y := k
+		z := fnv(x^y, 0x9e3779b9+y)
+		state[idx] = colossusRotl32(x+z, z%32) ^ y
+		scratchpad[k] = state[idx] ^ fnv(z, x+y)
+	}
+
+	var page [colossusPageWords]uint32
+	var tile [colossusTileWords]uint32
+	for r := uint32(0); r < colossusRounds; r++ {
+		a := state[r%colossusStateWords]
+		b := state[(r+5)%colossusStateWords]
+		c := acc[r%colossusAccWords]
+
+		dp := uint32(0)
+		if numPages > 0 {
+			dp = fnv(a^r, b+c) % numPages
+			pageLookup(dp, &page)
+		} else {
+			for i := range page {
+				page[i] = 0
+			}
+		}
+		sp := fnv(b^r, a+c) % colossusNumTiles
+		copy(tile[:], scratchpad[int(sp)*colossusTileWords:int(sp+1)*colossusTileWords])
+
+		for p := uint32(0); p < colossusInternalPasses; p++ {
+			for i := uint32(0); i < colossusTileWords; i++ {
+				x := tile[i]
+				y := page[(i+p*13)%colossusPageWords]
+				sidx := (i + r + p) % colossusStateWords
+				aidx := (i + p) % colossusAccWords
+				z := state[sidx]
+				w := acc[aidx]
+
+				m1 := fnv(x^z, y+r)
+				m2 := colossusRotl32(x+y+w+p, (z^y)%32)
+				m3 := (z * 0x9e3779b1) + (w ^ i)
+				newX := m1 ^ m2 ^ m3
+
+				tile[i] = newX
+				state[sidx] = fnv(z^y, newX+i)
+				acc[aidx] = fnv(w^newX, y+r+p)
+			}
+		}
+
+		state[r%colossusStateWords] ^= tile[(r*7)%colossusTileWords]
+		state[(r+3)%colossusStateWords] = fnv(state[(r+3)%colossusStateWords], tile[(r*11+5)%colossusTileWords])
+		acc[r%colossusAccWords] ^= tile[(r*13+9)%colossusTileWords]
+
+		copy(scratchpad[int(sp)*colossusTileWords:int(sp+1)*colossusTileWords], tile[:])
+	}
+
+	finalState := colossusStateBytes(&state, &acc)
+	mixDigest := crypto.Keccak256(finalState)
+	result := crypto.Keccak256(seed, mixDigest)
+	return mixDigest, result
+}
+
+func colossusHashLight(size uint64, cache []uint32, sealHash []byte, nonce uint64) ([]byte, []byte) {
+	numPages := colossusNumPages(size)
+	keccak512 := makeHasher(sha3.NewLegacyKeccak512())
+	return colossusHashCore(numPages, sealHash, nonce, func(pageIndex uint32, out *[colossusPageWords]uint32) {
+		colossusLookupPageLight(cache, pageIndex, keccak512, out)
+	})
+}
+
+func colossusHashFull(dataset []uint32, sealHash []byte, nonce uint64) ([]byte, []byte) {
+	datasetWords := len(dataset) - (len(dataset) % colossusPageWords)
+	numPages := uint32(datasetWords / colossusPageWords)
+	return colossusHashCore(numPages, sealHash, nonce, func(pageIndex uint32, out *[colossusPageWords]uint32) {
+		colossusLookupPageFull(dataset[:datasetWords], pageIndex, out)
+	})
 }
 
 // maxEpoch bounds the pre-generated future cache/dataset epoch in the LRU.

--- a/consensus/ethash/colossus_test.go
+++ b/consensus/ethash/colossus_test.go
@@ -1,0 +1,91 @@
+package ethash
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func makeLightAndFullInputs(t *testing.T, datasetBytes uint64, epoch uint64) ([]uint32, []uint32) {
+	t.Helper()
+	seed := seedHash(epoch*epochLength + 1)
+	cache := make([]uint32, cacheSize(epoch*epochLength+1)/4)
+	generateCache(cache, epoch, seed)
+	dataset := make([]uint32, datasetBytes/4)
+	generateDataset(dataset, epoch, cache)
+	return cache, dataset
+}
+
+func TestColossusHashLightFullMatch(t *testing.T) {
+	cache, dataset := makeLightAndFullInputs(t, 32*1024, 0)
+	sealHash := make([]byte, 32)
+	for _, nonce := range []uint64{0, 1, 7, 42, 999} {
+		lightDigest, lightResult := colossusHashLight(32*1024, cache, sealHash, nonce)
+		fullDigest, fullResult := colossusHashFull(dataset, sealHash, nonce)
+		if hex.EncodeToString(lightDigest) != hex.EncodeToString(fullDigest) {
+			t.Fatalf("digest mismatch for nonce %d", nonce)
+		}
+		if hex.EncodeToString(lightResult) != hex.EncodeToString(fullResult) {
+			t.Fatalf("result mismatch for nonce %d", nonce)
+		}
+	}
+}
+
+func TestColossusTailTruncationAndPageBoundary(t *testing.T) {
+	cache, dataset := makeLightAndFullInputs(t, 32*1024, 0)
+	sealHash := []byte("0123456789abcdef0123456789abcdef")
+	nonce := uint64(123)
+
+	baseDigest, baseResult := colossusHashFull(dataset, sealHash, nonce)
+	withTailDigest, withTailResult := colossusHashFull(append(append([]uint32{}, dataset...), 1, 2, 3), sealHash, nonce)
+	if hex.EncodeToString(baseDigest) != hex.EncodeToString(withTailDigest) || hex.EncodeToString(baseResult) != hex.EncodeToString(withTailResult) {
+		t.Fatalf("full hash should ignore tail words beyond effective dataset page boundary")
+	}
+
+	lightA1, lightB1 := colossusHashLight(32*1024, cache, sealHash, nonce)
+	lightA2, lightB2 := colossusHashLight(32*1024+17, cache, sealHash, nonce)
+	if hex.EncodeToString(lightA1) != hex.EncodeToString(lightA2) || hex.EncodeToString(lightB1) != hex.EncodeToString(lightB2) {
+		t.Fatalf("light hash should ignore tail bytes beyond effective dataset bytes")
+	}
+}
+
+func TestColossusGoldenVectors(t *testing.T) {
+	cache0, dataset0 := makeLightAndFullInputs(t, 32*1024, 0)
+	cache1, dataset1 := makeLightAndFullInputs(t, 32*1024, 1)
+
+	// Provenance: vectors are derived from the ColossusHash-v1.1 spec formulas
+	// in this package and frozen from a standalone reproduction script.
+	// Regenerate with:
+	//   GO111MODULE=off go run ./tmp_vec_main.go
+	vectors := []struct {
+		name       string
+		dataset    []uint32
+		cache      []uint32
+		datasetLen uint64
+		sealHash   string
+		nonce      uint64
+		digestHex  string
+		resultHex  string
+	}{
+		{name: "epoch0_nonce0", dataset: dataset0, cache: cache0, datasetLen: 32 * 1024, sealHash: "0000000000000000000000000000000000000000000000000000000000000000", nonce: 0, digestHex: "563c594018ce5bbed726d57e3cd319db39c5eebfefc467866b499adc8a77f50f", resultHex: "b06d89147224eb6c91d4639e65bed48c10c72b5cff54011c120303ef22ac96a3"},
+		{name: "epoch0_nonce7", dataset: dataset0, cache: cache0, datasetLen: 32*1024 + 77, sealHash: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", nonce: 7, digestHex: "2fa020e77a6110794035cb4b784c3347163dfe75a12ac5930c107dd8f7acbaf5", resultHex: "50f2b9dd66dc31c24dfc178dbe6037c5817f196339b27118237bc4775c08fc3f"},
+		{name: "epoch1_nonce42", dataset: dataset1, cache: cache1, datasetLen: 32 * 1024, sealHash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", nonce: 42, digestHex: "a787b9ec9454d87d4a6e3d293e0df787ab13351c67a3e8002f8dab527c7eba3a", resultHex: "91945711a8c64c05a41a76871929e15326ce279628ca27e1825c99749b715ab4"},
+	}
+
+	for _, tc := range vectors {
+		sealHash, err := hex.DecodeString(tc.sealHash)
+		if err != nil {
+			t.Fatalf("decode seal hash: %v", err)
+		}
+		lightDigest, lightResult := colossusHashLight(tc.datasetLen, tc.cache, sealHash, tc.nonce)
+		fullDigest, fullResult := colossusHashFull(tc.dataset, sealHash, tc.nonce)
+		if hex.EncodeToString(lightDigest) != hex.EncodeToString(fullDigest) || hex.EncodeToString(lightResult) != hex.EncodeToString(fullResult) {
+			t.Fatalf("full/light mismatch for %s", tc.name)
+		}
+		if got := hex.EncodeToString(fullDigest); got != tc.digestHex {
+			t.Fatalf("digest mismatch for %s: got %s", tc.name, got)
+		}
+		if got := hex.EncodeToString(fullResult); got != tc.resultHex {
+			t.Fatalf("result mismatch for %s: got %s", tc.name, got)
+		}
+	}
+}

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -141,7 +141,7 @@ func calcKeyBlockDifficultyByzantium(time uint64, parent *types.KeyBlockHeader) 
 	return x
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////
 // VerifyCandidate implements pow.Engine, checking whether the given candidate satisfies
 // the PoW difficulty requirements.
 func (ethash *Ethash) VerifyCandidate(chain types.KeyChainReader, candidate *types.Candidate) error {
@@ -209,7 +209,7 @@ func (ethash *Ethash) VerifyHeaderSeal(header *types.Header) error {
 	if ethash.config.PowMode == ModeTest {
 		size = 32 * 1024
 	}
-	digest, result := hashimotoLight(size, cache.cache, header.SealHash().Bytes(), header.Nonce.Uint64())
+	digest, result := colossusHashLight(size, cache.cache, header.SealHash().Bytes(), header.Nonce.Uint64())
 	runtime.KeepAlive(cache)
 
 	if !bytes.Equal(header.MixDigest[:], digest) {
@@ -239,13 +239,10 @@ func (ethash *Ethash) SealHeader(header *types.Header, stop <-chan struct{}) err
 	}
 
 	number := header.Number.Uint64()
-	cache := ethash.cache(number)
-	size := datasetSize(number)
-	if ethash.config.PowMode == ModeTest {
-		size = 32 * 1024
-	}
 	target := new(big.Int).Div(maxUint256, header.Difficulty)
 	hash := header.SealHash().Bytes()
+	dataset := ethash.dataset(number)
+	defer runtime.KeepAlive(dataset)
 
 	for nonce := uint64(0); ; nonce++ {
 		select {
@@ -253,11 +250,10 @@ func (ethash *Ethash) SealHeader(header *types.Header, stop <-chan struct{}) err
 			return errors.New("sealing aborted")
 		default:
 		}
-		digest, result := hashimotoLight(size, cache.cache, hash, nonce)
+		digest, result := colossusHashFull(dataset.dataset, hash, nonce)
 		if new(big.Int).SetBytes(result).Cmp(target) <= 0 {
 			header.Nonce = types.EncodeNonce(nonce)
 			header.MixDigest = common.BytesToHash(digest)
-			runtime.KeepAlive(cache)
 			return nil
 		}
 	}
@@ -330,7 +326,7 @@ func (ethash *Ethash) PowMode() uint {
 	return uint(ethash.config.PowMode)
 }
 
-//----------------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------
 // Author implements consensus.Engine, returning the header's coinbase as the
 // proof-of-work verified author of the block.
 func (ethash *Ethash) Author(header *types.Header) (common.Address, error) {


### PR DESCRIPTION
### Motivation

- Replace the normal-block PoW path (used by txblock.go) with the actual ColossusHash-v1.1 algorithm while preserving candidate/keyblock and Ethash dataset/cache lineage.
- Keep the `SealHeader`/`VerifyHeaderSeal` API and txblock integration contract unchanged so normal-block sealing/verification is pluggable without touching reconfig flows.

### Description

- Added Colossus constants, endian/rotate helpers, page/tile/scratchpad lookup functions, and the full v1.1 state machine to `consensus/ethash/algorithm.go`, and exported `colossusHashLight(...)` and `colossusHashFull(...)` which share a single core implementation but differ only in dataset page lookup.
- Implemented seed/state initialization, scratchpad init, the 64-round Colossus round function with 4 internal passes, and the final `MixDigest`/`Result` Keccak commitments inside the new core routine.`colossusHashCore`.
- Switched normal-block verification to use `colossusHashLight(...)` in `VerifyHeaderSeal` and switched normal-block mining to use `colossusHashFull(...)` over the full dataset in `SealHeader`, preserving fake/shared modes, difficulty/target logic, stop-channel behavior, and `runtime.KeepAlive` semantics.
- Kept all Ethash helpers (`seedHash`, `generateCache`, `generateDatasetItem`, `generateDataset`, `hashimoto*`) unchanged for candidate/keyblock flows and dataset lineage, and left `SealCandidate`/`VerifyCandidate` behavior intact.
- Added `consensus/ethash/colossus_test.go` with tests for light/full equivalence, page-boundary and tail-truncation behavior, and fixed golden vectors with explicit provenance and regeneration instructions.

### Testing

- Added unit tests in `consensus/ethash/colossus_test.go` (light/full equality, tail/page-boundary tests, and golden vectors); these tests were created and checked into the branch and use reproducible golden-vector guidance comments and regenerate helper instructions.
- Reproduced and captured golden-vector outputs with a standalone generator script (`tmp_vec_main.go`) run locally in the workspace and embedded the resulting vectors into the test file for future verification.
- Attempted full package test via `go test ./consensus/ethash ./reconfig`, but the environment here cannot run the full test-suite due to missing external GOPATH/module dependencies (e.g. `github.com/VictoriaMetrics/fastcache`, `github.com/shirou/gopsutil/cpu`, `golang.org/x/sys/...`), so automated test execution failed in this environment; formatting (`gofmt`) and local checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c39d84ab808330856b45d496bf3fe1)