### PR TITLE
Propagate VerifyHeader errors at startup and clarify ethash seal path

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -488,16 +488,13 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 		return consensus.ErrInvalidNumber
 	}
 
-	// Verify the engine specific seal securing normal blocks.
-	// Candidate/key block PoW remains on the separate VerifyCandidate path.
+	// Verify the engine specific seal securing the block.
+	// In UMA-PoW normal block headers use the Colossus path.
 	if seal {
 		if err := ethash.VerifyHeaderSeal(header); err != nil {
 			return err
 		}
 	}
-
-	// If all checks passed, validate any special fields for hard forks
-	// DAO/fork-specific checks are intentionally not enabled in this branch.
 	return nil
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -326,7 +326,9 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	// The first thing the node will do is reconstruct the verification data for
 	// the head block (ethash cache or clique voting snapshot). Might as well do
 	// it in advance.
-	bc.engine.VerifyHeader(bc, bc.CurrentHeader(), true)
+	if err := bc.engine.VerifyHeader(bc, bc.CurrentHeader(), true); err != nil {
+		return nil, err
+	}
 
 	// Check the current state of the block hashes and make sure that we do not have any of the bad blocks in our chain
 	for hash := range BadHashes {


### PR DESCRIPTION
### Motivation
- Surface and propagate header seal verification errors during blockchain initialization and clarify which seal path is used for UMA-PoW/Colossus headers.

### Description
- Update `consensus/ethash/consensus.go` to clarify the engine seal verification comment and keep normal block seal validation on `VerifyHeaderSeal` for UMA-PoW/Colossus headers.
- Change `core/blockchain.go` to propagate errors returned by `bc.engine.VerifyHeader(bc, bc.CurrentHeader(), true)` by returning the error from `NewBlockChain` instead of ignoring it.

### Testing
- Attempted `go test ./consensus/ethash ./core`, which could not run in this environment because the repository is not configured as a Go module (`go` reported to run `go mod init`), so no unit test results were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55950fd508330bc17cb5da2c2b30b)