### PR TITLE
core: stabilize key-chain startup/reset and handle decode failures

### DIFF
--- a/core/keyblockchain.go
+++ b/core/keyblockchain.go
@@ -193,7 +193,27 @@ func (kbc *KeyBlockChain) Reset() error {
 // ResetWithGenesisBlock purges the entire blockchain, restoring it to the
 // specified genesis state.
 func (kbc *KeyBlockChain) ResetWithGenesisBlock(genesis *types.KeyBlock) error {
+	if genesis == nil {
+		return ErrNoKeyGenesis
+	}
 
+	batch := kbc.db.NewBatch()
+	rawdb.WriteTd(batch, genesis.Hash(), genesis.NumberU64(), genesis.Difficulty())
+	rawdb.WriteKeyBlock(batch, genesis)
+	rawdb.WriteKeyBlockHash(batch, genesis.Hash(), genesis.NumberU64())
+	rawdb.WriteHeadKeyBlockHash(batch, genesis.Hash())
+	rawdb.WriteHeadKeyHeaderHash(batch, genesis.Hash())
+	if err := batch.Write(); err != nil {
+		return err
+	}
+
+	kbc.genesisBlock = genesis
+	kbc.currentBlock.Store(genesis)
+	kbc.khc.SetGenesis(genesis.Header())
+	kbc.khc.SetCurrentHeader(genesis.Header())
+
+	kbc.blockCache.Purge()
+	kbc.blockRLPCache.Purge()
 	return nil
 }
 
@@ -219,7 +239,7 @@ func (kbc *KeyBlockChain) loadLastState() error {
 	kbc.currentBlock.Store(currentBlock)
 	// Restore the last known head header
 	currentHeader := currentBlock.Header()
-	if head := rawdb.ReadHeadHeaderHash(kbc.db); head != (common.Hash{}) {
+	if head := rawdb.ReadHeadKeyHeaderHash(kbc.db); head != (common.Hash{}) {
 		if header := kbc.GetHeaderByHash(head); header != nil {
 			currentHeader = header
 		}
@@ -255,6 +275,7 @@ func (kbc *KeyBlockChain) InsertBlockFromData(data []byte) error {
 	b := types.DecodeToKeyBlock(data)
 	if b == nil {
 		log.Error("InsertBlockFromData DecodeToKeyBlock return nil")
+		return errors.New("insert key block from data: decode failed")
 	}
 	_, err := kbc.insert_Chain(types.KeyBlocks{b})
 	if err != nil {


### PR DESCRIPTION
### Motivation

- Stabilize key-chain startup and recovery so the node can correctly restore the key header head and recover from missing/corrupt head state.
- Prevent a clear crash point when decoding keyblocks from external data by failing fast on invalid RLP.
- Provide a working repair/reset path by implementing genesis reset logic that reinitialises DB markers and in-memory state.

### Description

- Implemented `ResetWithGenesisBlock(genesis *types.KeyBlock)` to write genesis TD, header, body, canonical mapping and head markers into the DB and to refresh `genesisBlock`, `currentBlock`, header chain genesis/current header and purge block caches.
- Fixed `loadLastState()` to read the key-header head using `ReadHeadKeyHeaderHash` (instead of the normal header head) so the keychain restores the correct header head on startup.
- Hardened `InsertBlockFromData()` to return an immediate error when `types.DecodeToKeyBlock(data)` returns `nil`, avoiding downstream nil dereference/crash paths.
- Minor housekeeping: purge `blockCache` and `blockRLPCache` during reset to ensure in-memory caches reflect the reset state.

### Testing

- Ran `gofmt -w core/keyblockchain.go` to format the modified file, which completed successfully.
- Attempted `go test ./core -run TestDoesNotExist` but the repository is not configured as a Go module so the test run could not start (environment reported `go: cannot find main module`).
- Attempted `GO111MODULE=off go test ./core/...` and the run failed due to missing external dependencies and GOPATH/module resolution in the execution environment, not due to the code changes themselves.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5651c3f448330bd4a0f3e27678890)