### PR TITLE
types: define canonical key-block PoW seal preimage

### DIFF
--- a/core/types/keyblock.go
+++ b/core/types/keyblock.go
@@ -57,6 +57,23 @@ func (h *KeyBlockHeader) HashWithCandi() common.Hash {
 	})
 }
 
+// SealHash returns the canonical key-block PoW preimage.
+//
+// The seal hash intentionally excludes PoW seal fields (MixDigest, Nonce) and
+// only includes canonical key-block header fields that can be reconstructed
+// from chain data.
+func (h *KeyBlockHeader) SealHash() common.Hash {
+	return rlpHash([]interface{}{
+		h.ParentHash,
+		h.Difficulty,
+		h.Number,
+		h.Time,
+		h.BlockType,
+		h.CommitteeHash,
+		h.T_Number,
+	})
+}
+
 // Size returns the approximate memory used by all internal contents. It is used
 // to approximate and limit the memory consumption of various caches.
 func (h *KeyBlockHeader) Size() common.StorageSize {


### PR DESCRIPTION
### Motivation
- Provide a canonical, chain-reconstructable PoW preimage for key blocks so downstream verification (`VerifyKeyHeaderSeal`) and mining (`mineCandidate`) have a stable basis that can be rebuilt from canonical header fields.

### Description
- Add `KeyBlockHeader.SealHash()` in `core/types/keyblock.go` that returns `rlpHash` over `ParentHash`, `Difficulty`, `Number`, `Time`, `BlockType`, `CommitteeHash`, and `T_Number`, explicitly excluding `MixDigest` and `Nonce`, while keeping `HashWithCandi()` behavior unchanged.

### Testing
- Ran `go test ./core/types` and `GO111MODULE=off go test ./core/types`, both of which failed in this sandbox due to missing Go module/GOPATH dependencies, so no passing unit-test results are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c566ad145c83308c50cc204132f167)