### PR TITLE
ethash: use canonical KeyBlock `SealHash` for mining and verification

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -157,28 +157,33 @@ func (ethash *Ethash) VerifyCandidate(chain types.KeyChainReader, candidate *typ
 	if ethash.shared != nil {
 		return ethash.shared.VerifyCandidate(chain, candidate)
 	}
-	// Ensure that we have a valid difficulty for the block
-	if candidate.KeyCandidate.Difficulty == nil || candidate.KeyCandidate.Difficulty.Sign() <= 0 {
+	return ethash.VerifyKeyHeaderSeal(candidate.KeyCandidate)
+}
+
+// VerifyKeyHeaderSeal checks whether the given key block header satisfies
+// ethash PoW requirements.
+func (ethash *Ethash) VerifyKeyHeaderSeal(header *types.KeyBlockHeader) error {
+	if header.Difficulty == nil || header.Difficulty.Sign() <= 0 {
 		return errInvalidDifficulty
 	}
-	// Recompute the digest and PoW value and verify against the header
-	number := candidate.KeyCandidate.Number.Uint64()
+	// Recompute the digest and PoW value and verify against the header.
+	number := header.Number.Uint64()
 
 	cache := ethash.cache(number)
 	size := datasetSize(number)
 	if ethash.config.PowMode == ModeTest {
 		size = 32 * 1024
 	}
-	digest, result := hashimotoLight(size, cache.cache, candidate.HashNoNonce().Bytes(), candidate.KeyCandidate.Nonce.Uint64())
+	digest, result := hashimotoLight(size, cache.cache, header.SealHash().Bytes(), header.Nonce.Uint64())
 	// Caches are unmapped in a finalizer. Ensure that the cache stays live
 	// until after the call to hashimotoLight so it's not unmapped while being used.
 	runtime.KeepAlive(cache)
 
-	if !bytes.Equal(candidate.KeyCandidate.MixDigest[:], digest) {
+	if !bytes.Equal(header.MixDigest[:], digest) {
 		return errInvalidMixDigest
 	}
 
-	target := new(big.Int).Div(maxUint256, candidate.KeyCandidate.Difficulty)
+	target := new(big.Int).Div(maxUint256, header.Difficulty)
 	if new(big.Int).SetBytes(result).Cmp(target) > 0 {
 		return errInvalidPoW
 	}

--- a/consensus/ethash/sealer.go
+++ b/consensus/ethash/sealer.go
@@ -97,7 +97,7 @@ func (ethash *Ethash) SealCandidate(candidate *types.Candidate, stop <-chan stru
 func (ethash *Ethash) mineCandidate(candidate *types.Candidate, id int, seed uint64, abort chan struct{}, found chan *types.Candidate) {
 	// Extract some data from the header
 	var (
-		hash    = candidate.HashNoNonce().Bytes()
+		hash    = candidate.KeyCandidate.SealHash().Bytes()
 		target  = new(big.Int).Div(maxUint256, candidate.KeyCandidate.Difficulty)
 		number  = candidate.KeyCandidate.Number.Uint64()
 		dataset = ethash.dataset(number)


### PR DESCRIPTION
### Motivation
- Prevent a mismatch where mining and verification use different PoW preimages, which can cause blocks to be mined but later rejected (or vice versa).
- `HashNoNonce()` depends on candidate identity and is not suitable for canonical revalidation, so mining/verification must use the canonical header preimage `SealHash()`.

### Description
- Changed `VerifyCandidate` to delegate key-block verification to a new verifier that operates on the canonical header preimage by calling `VerifyKeyHeaderSeal(candidate.KeyCandidate)` in `consensus/ethash/consensus.go`.
- Added `VerifyKeyHeaderSeal(*types.KeyBlockHeader)` to centralize key-block PoW verification logic using `header.SealHash().Bytes()` and `hashimotoLight`.
- Updated the miner to use the canonical preimage by switching the mining input from `candidate.HashNoNonce().Bytes()` to `candidate.KeyCandidate.SealHash().Bytes()` in `consensus/ethash/sealer.go` (`mineCandidate`).
- Ran code formatting via `gofmt` on the modified files `consensus/ethash/consensus.go` and `consensus/ethash/sealer.go`.

### Testing
- Ran `gofmt -w consensus/ethash/consensus.go consensus/ethash/sealer.go` which completed successfully.
- Attempted `go test ./consensus/ethash` but the environment lacks a proper Go module/GOPATH setup and external dependencies, so tests could not run (failed to build).
- Attempted `GO111MODULE=off go test ./consensus/ethash` which also failed due to missing GOPATH dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c56794fbf08330b469710f44a3a46e)