### PR TITLE
core: strengthen key block validation checks

### DIFF
--- a/core/keyblockchain.go
+++ b/core/keyblockchain.go
@@ -5,6 +5,7 @@ import (
 
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"errors"
 	"fmt"
@@ -22,6 +23,10 @@ import (
 	"github.com/cypherium/cypher/rlp"
 	lru "github.com/hashicorp/golang-lru"
 )
+
+type keyHeaderSealVerifier interface {
+	VerifyKeyHeaderSeal(header *types.KeyBlockHeader) error
+}
 
 var (
 	ErrNoKeyGenesis   = errors.New("Genesis not found in key block chain")
@@ -466,8 +471,38 @@ func (kbc *KeyBlockChain) ValidateKeyBlock(block *types.KeyBlock) error {
 		return types.ErrKnownBlock
 	}
 
+	if blockNumber == 0 {
+		return types.ErrInvalidNumber
+	}
 	if !kbc.HasBlock(block.ParentHash(), blockNumber-1) {
 		return types.ErrUnknownAncestor
+	}
+
+	parent := kbc.GetHeader(block.ParentHash(), blockNumber-1)
+	if parent == nil {
+		return types.ErrUnknownAncestor
+	}
+	header := block.Header()
+	if header.Time <= parent.Time {
+		return fmt.Errorf("invalid keyblock timestamp: parent %d, current %d", parent.Time, header.Time)
+	}
+	if header.Time > uint64(time.Now().Unix())+kbc.chainConfig.AllowedFutureBlockTime {
+		return types.ErrFutureBlock
+	}
+	expectedDiff := kbc.engine.CalcKeyBlockDifficulty(kbc, header.Time, parent)
+	if expectedDiff == nil || header.Difficulty == nil || expectedDiff.Cmp(header.Difficulty) != 0 {
+		return fmt.Errorf("invalid keyblock difficulty: have %v, want %v", header.Difficulty, expectedDiff)
+	}
+
+	sealVerifier, ok := kbc.engine.(keyHeaderSealVerifier)
+	if !ok {
+		return fmt.Errorf("consensus engine does not support key header seal verification")
+	}
+	if err := sealVerifier.VerifyKeyHeaderSeal(header); err != nil {
+		return err
+	}
+	if !block.TypeCheck(parent.T_Number) {
+		return fmt.Errorf("invalid keyblock type: block type=%d t_number=%d parent_t_number=%d", block.BlockType(), block.T_Number(), parent.T_Number)
 	}
 	return nil
 }


### PR DESCRIPTION
### Motivation
- `ValidateKeyBlock` previously only checked if a key block was known and whether its parent exists; it needs to perform full validation (timestamp, difficulty, PoW seal and type checks) to avoid accepting invalid key blocks.

### Description
- Added stronger key-block validation in `KeyBlockChain.ValidateKeyBlock`, including parent header fetch and a guard rejecting `blockNumber == 0` via `types.ErrInvalidNumber`.
- Added timestamp checks against the parent (`header.Time > parent.Time`) and against configured future allowance using `chainConfig.AllowedFutureBlockTime`.
- Verified header difficulty using `engine.CalcKeyBlockDifficulty` and compared it with the header's `Difficulty` field.
- Performed PoW seal verification by introducing a `keyHeaderSealVerifier` interface and invoking `VerifyKeyHeaderSeal` on the consensus engine, and added `TypeCheck(parent.T_Number)` to validate block type consistency.

### Testing
- Ran `go test ./core -run TestDoesNotExist`, which failed to run because the repository root lacks Go module metadata (`go: cannot find main module`), so no unit tests were executed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c56888a07483309319e105ebea26a6)