### PR TITLE
core: fix key-chain TD to cumulative semantics

### DIFF
--- a/core/keyblockchain.go
+++ b/core/keyblockchain.go
@@ -203,7 +203,8 @@ func (kbc *KeyBlockChain) ResetWithGenesisBlock(genesis *types.KeyBlock) error {
 	}
 
 	batch := kbc.db.NewBatch()
-	rawdb.WriteTd(batch, genesis.Hash(), genesis.NumberU64(), genesis.Difficulty())
+	// Genesis block starts cumulative TD from its own difficulty.
+	rawdb.WriteTd(batch, genesis.Hash(), genesis.NumberU64(), new(big.Int).Set(genesis.Difficulty()))
 	rawdb.WriteKeyBlock(batch, genesis)
 	rawdb.WriteKeyBlockHash(batch, genesis.Hash(), genesis.NumberU64())
 	rawdb.WriteHeadKeyBlockHash(batch, genesis.Hash())
@@ -263,7 +264,19 @@ func (kbc *KeyBlockChain) loadLastState() error {
 // insert injects a new head keyblock into the current keyblock chain.
 // Note, this function assumes that the `mu` mutex is held!
 func (kbc *KeyBlockChain) insert(block *types.KeyBlock) error {
-	if err := kbc.khc.WriteTd(block.Hash(), block.NumberU64(), block.Difficulty()); err != nil {
+	var td *big.Int
+	if block.NumberU64() == 0 {
+		// Genesis block starts cumulative TD from its own difficulty.
+		td = new(big.Int).Set(block.Difficulty())
+	} else {
+		parentTd := kbc.GetTd(block.ParentHash(), block.NumberU64()-1)
+		if parentTd == nil {
+			return consensus.ErrUnknownAncestor
+		}
+		td = new(big.Int).Add(parentTd, block.Difficulty())
+	}
+
+	if err := kbc.khc.WriteTd(block.Hash(), block.NumberU64(), td); err != nil {
 		return err
 	}
 	rawdb.WriteKeyBlock(kbc.db, block)


### PR DESCRIPTION
### Motivation
- The key-chain previously wrote local block difficulty as the stored TD, breaking TD semantics; TD must be cumulative along the chain.

### Description
- In `insert` compute cumulative TD before writing: if the block is genesis use its own difficulty, otherwise load the parent's TD and set `td = parentTd + block.Difficulty()`, returning `consensus.ErrUnknownAncestor` when the parent TD is missing.
- In `ResetWithGenesisBlock` explicitly write a copy of `genesis.Difficulty()` (via `new(big.Int).Set(...)`) so the genesis entry represents the cumulative starting TD.
- Only `core/keyblockchain.go` was changed; `core/keyheaderchain.go` was left untouched.

### Testing
- Ran `go test ./core/...` which failed in this environment due to the repository not being resolved as a Go module (setup error).
- Ran `go test ./...` which also failed here for the same Go module resolution error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c569c0a22083308aebf2a45b5e384c)