### PR TITLE
core: verify startup head seals directly

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -82,6 +82,10 @@ var (
 	errInsertionInterrupted = errors.New("insertion is interrupted")
 )
 
+type headerSealVerifier interface {
+	VerifyHeaderSeal(header *types.Header) error
+}
+
 const (
 	bodyCacheLimit      = 128
 	blockCacheLimit     = 128
@@ -323,10 +327,13 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 			}
 		}
 	}
-	// The first thing the node will do is reconstruct the verification data for
-	// the head block (ethash cache or clique voting snapshot). Might as well do
-	// it in advance.
-	if err := bc.engine.VerifyHeader(bc, bc.CurrentHeader(), true); err != nil {
+	// Verify the head seal directly so startup self-check is not short-circuited
+	// by known-header fast paths in VerifyHeader.
+	sealVerifier, ok := bc.engine.(headerSealVerifier)
+	if !ok {
+		return nil, fmt.Errorf("consensus engine does not support header seal verification")
+	}
+	if err := sealVerifier.VerifyHeaderSeal(bc.CurrentHeader()); err != nil {
 		return nil, err
 	}
 

--- a/core/keyblockchain.go
+++ b/core/keyblockchain.go
@@ -107,6 +107,14 @@ func NewKeyBlockChain(cph Backend, db ethdb.Database, cacheConfig *CacheConfig, 
 	if err := kbc.loadLastState(); err != nil {
 		return nil, err
 	}
+	currentHeader := kbc.CurrentHeader()
+	sealVerifier, ok := kbc.engine.(keyHeaderSealVerifier)
+	if !ok {
+		return nil, fmt.Errorf("consensus engine does not support key header seal verification")
+	}
+	if err := sealVerifier.VerifyKeyHeaderSeal(currentHeader); err != nil {
+		return nil, err
+	}
 
 	return kbc, nil
 }


### PR DESCRIPTION
### Motivation
- Ensure startup self-check actually validates block/keyblock seals by avoiding `VerifyHeader(..., true)` known-header short-circuit and calling the seal-specific verification directly.

### Description
- In `NewBlockChain()` add a `headerSealVerifier` type assertion and call `VerifyHeaderSeal(bc.CurrentHeader())`, returning a clear error if the consensus engine doesn't implement it.
- In `NewKeyBlockChain()` call `VerifyKeyHeaderSeal(currentHeader)` on the configured engine and return an error when the engine lacks the seal verifier.

### Testing
- Ran `gofmt -w core/blockchain.go core/keyblockchain.go` successfully to normalize formatting. 
- Attempted `go test ./core -run TestDoesNotExist`, which failed in this workspace because no `go.mod` is defined at the repository root (module resolution failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c56ada96b88330bb19e86327d1d410)