### PR TITLE
core: pre-validate embedded key block before normal block commit

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -181,3 +181,20 @@ func (v *BlockValidator) VerifySignature(block *types.Block) error {
 	}
 	return nil
 }
+
+func (v *BlockValidator) DecodeAndValidateEmbeddedKeyBlock(block *types.Block) error {
+	if block.BlockType() != types.Key_Block {
+		return nil
+	}
+	if len(block.KeyInfo()) == 0 {
+		return fmt.Errorf("key block info is required for key block %x", block.Hash())
+	}
+	if v.bc == nil || v.bc.keyBlockChain == nil {
+		return fmt.Errorf("key block chain is not initialized")
+	}
+	kb := types.DecodeToKeyBlock(block.KeyInfo())
+	if kb == nil {
+		return fmt.Errorf("embedded key block decode failed")
+	}
+	return v.bc.keyBlockChain.ValidateKeyBlock(kb)
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1944,6 +1944,10 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool, verifySi
 		storageHashTimer.Update(statedb.StorageHashes) // Storage hashes are complete, we can mark them
 
 		blockValidationTimer.Update(time.Since(substart) - (statedb.AccountHashes + statedb.StorageHashes - triehash))
+		if err := bc.validator.DecodeAndValidateEmbeddedKeyBlock(block); err != nil {
+			atomic.StoreUint32(&followupInterrupt, 1)
+			return it.index, err
+		}
 		// Write the block to the chain and get the status.
 		substart = time.Now()
 		status, err := bc.writeBlockWithState(block, receipts, logs, statedb, false)

--- a/core/types.go
+++ b/core/types.go
@@ -33,6 +33,8 @@ type Validator interface {
 	// gas used.
 	ValidateState(block *types.Block, state *state.StateDB, receipts types.Receipts, usedGas uint64) error
 
+	DecodeAndValidateEmbeddedKeyBlock(block *types.Block) error
+
 	VerifySignature(block *types.Block) error
 }
 


### PR DESCRIPTION
### Motivation
- Prevent divergence between the normal chain and key chain by pre-validating embedded key block data before writing the normal block state. 
- Currently the embedded key block is inserted into the key chain after the normal block write, which can leave the chains inconsistent if key insertion fails. 
- Keep existing signature semantics: `VerifySignature()` still uses `block.KeyHash()` as the active committee anchor and we do not enforce `kb.Hash() == block.KeyHash()` at this stage.

### Description
- Add `DecodeAndValidateEmbeddedKeyBlock(block *types.Block) error` to the `Validator` interface in `core/types.go`.
- Implement `BlockValidator.DecodeAndValidateEmbeddedKeyBlock` in `core/block_validator.go` to perform pre-validation only for `BlockType == types.Key_Block`, enforcing that `KeyInfo` is present, decoding via `types.DecodeToKeyBlock`, and running `keyBlockChain.ValidateKeyBlock(kb)`; it returns an error on any failure and checks that `bc.keyBlockChain` is initialized.
- Call `bc.validator.DecodeAndValidateEmbeddedKeyBlock(block)` in `insertChain` (in `core/blockchain.go`) immediately before `writeBlockWithState()` and abort the insertion when pre-validation fails by returning the error and setting the followup interrupt.
- Leave actual insertion call `keyBlockChain.InsertBlockFromData(block.KeyInfo())` in place (unchanged) after the state write; this change only adds pre-validation to avoid writing a normal block when its embedded key block is invalid.

### Testing
- Attempted `go test ./core/...` but it could not run in this environment because the repository workspace does not contain a root `go.mod`, so the test run failed due to module setup rather than code issues (output: "directory prefix core does not contain main module or its selected dependencies").

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c56be2ea2c8330b4af6d74278424a0)