### PR TITLE
core: make normal/key block commits atomic

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1445,7 +1445,7 @@ func (bc *BlockChain) WriteBlockWithState(block *types.Block, receipts []*types.
 	bc.chainmu.Lock()
 	defer bc.chainmu.Unlock()
 
-	return bc.writeBlockWithState(block, receipts, logs, state, emitHeadEvent)
+	return bc.writeBlockWithState(block, receipts, logs, state, emitHeadEvent, nil)
 }
 
 // function specifically added for Raft consensus. This is called from mintNewBlock
@@ -1463,7 +1463,7 @@ func (bc *BlockChain) CommitBlockWithState(deleteEmptyObjects bool, state *state
 
 // writeBlockWithState writes the block and all associated state to the database,
 // but is expects the chain mutex to be held.
-func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB, emitHeadEvent bool) (status WriteStatus, err error) {
+func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB, emitHeadEvent bool, embeddedKey *types.KeyBlock) (status WriteStatus, err error) {
 	bc.wg.Add(1)
 	defer bc.wg.Done()
 
@@ -1486,6 +1486,15 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	rawdb.WriteBlock(blockBatch, block)
 	rawdb.WriteReceipts(blockBatch, block.Hash(), block.NumberU64(), receipts)
 	rawdb.WritePreimages(blockBatch, state.Preimages())
+	if embeddedKey != nil {
+		keyExternTd, err := bc.keyBlockChain.PrepareInsert(embeddedKey)
+		if err != nil {
+			return NonStatTy, err
+		}
+		if err := bc.keyBlockChain.InsertPrepared(blockBatch, embeddedKey, keyExternTd); err != nil {
+			return NonStatTy, err
+		}
+	}
 	if err := blockBatch.Write(); err != nil {
 		log.Crit("Failed to write block into disk", "err", err)
 	}
@@ -1950,19 +1959,19 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool, verifySi
 		}
 		// Write the block to the chain and get the status.
 		substart = time.Now()
-		status, err := bc.writeBlockWithState(block, receipts, logs, statedb, false)
+		var embeddedKey *types.KeyBlock
+		if block.BlockType() == types.Key_Block {
+			embeddedKey = types.DecodeToKeyBlock(block.KeyInfo())
+			if embeddedKey == nil {
+				atomic.StoreUint32(&followupInterrupt, 1)
+				return it.index, errors.New("embedded key block decode failed")
+			}
+		}
+		status, err := bc.writeBlockWithState(block, receipts, logs, statedb, false, embeddedKey)
 		atomic.StoreUint32(&followupInterrupt, 1)
 		if err != nil {
 			return it.index, err
 		}
-		//--write keyblock----------------------------------------------------------------------------------------------
-		if block.BlockType() == types.Key_Block {
-			err := bc.keyBlockChain.InsertBlockFromData(block.KeyInfo())
-			if err != nil {
-				return it.index, err
-			}
-		}
-		//------------------------------------------------------------------------------------------------
 		// Update the metrics touched during block commit
 		//accountCommitTimer.Update(statedb.AccountCommits)   // Account commits are complete, we can mark them
 		//storageCommitTimer.Update(statedb.StorageCommits)   // Storage commits are complete, we can mark them

--- a/core/keyblockchain.go
+++ b/core/keyblockchain.go
@@ -310,6 +310,52 @@ func (kbc *KeyBlockChain) InsertBlockFromData(data []byte) error {
 	return err
 }
 
+// PrepareInsert validates a key block and prepares its cumulative TD for insertion.
+// A nil externTd means the block is already known and no insertion is needed.
+func (kbc *KeyBlockChain) PrepareInsert(block *types.KeyBlock) (*big.Int, error) {
+	err := kbc.ValidateKeyBlock(block)
+	switch {
+	case err == types.ErrKnownBlock:
+		if kbc.CurrentBlockN() >= block.NumberU64() {
+			return nil, nil
+		}
+	case err != nil:
+		return nil, err
+	}
+
+	var externTd *big.Int
+	if block.NumberU64() == 0 {
+		externTd = new(big.Int).Set(block.Difficulty())
+	} else {
+		parentTd := kbc.GetTd(block.ParentHash(), block.NumberU64()-1)
+		if parentTd == nil {
+			return nil, consensus.ErrUnknownAncestor
+		}
+		externTd = new(big.Int).Add(parentTd, block.Difficulty())
+	}
+	return externTd, nil
+}
+
+// InsertPrepared appends the key block write operations into batch and updates
+// in-memory key chain heads.
+func (kbc *KeyBlockChain) InsertPrepared(batch ethdb.Batch, block *types.KeyBlock, externTd *big.Int) error {
+	if externTd == nil {
+		return nil
+	}
+	rawdb.WriteTd(batch, block.Hash(), block.NumberU64(), externTd)
+	rawdb.WriteKeyBlock(batch, block)
+	rawdb.WriteKeyBlockHash(batch, block.Hash(), block.NumberU64())
+	rawdb.WriteHeadKeyBlockHash(batch, block.Hash())
+	rawdb.WriteHeadKeyHeaderHash(batch, block.Hash())
+
+	kbc.khc.tdCache.Add(block.Hash(), new(big.Int).Set(externTd))
+	kbc.blockCache.Add(block.Hash(), block)
+	kbc.currentBlock.Store(block)
+	kbc.khc.currentHeader.Store(block.Header())
+	kbc.khc.currentHeaderHash = block.Hash()
+	return nil
+}
+
 // InsertChain attempts to insert the given batch of key blocks in to the keyblock
 // chain. If an error is returned it will return the index number of the failing block
 // as well an error describing what went wrong.


### PR DESCRIPTION
### Motivation
- Make persistence of normal blocks and their embedded key blocks atomic to avoid partial commits and ensure total-difficulty / head consistency across both chains.

### Description
- Added `KeyBlockChain.PrepareInsert(block *types.KeyBlock) (*big.Int, error)` to validate an embedded key block and compute its cumulative TD, returning `nil` when the block is already known. (core/keyblockchain.go)
- Added `KeyBlockChain.InsertPrepared(batch ethdb.Batch, block *types.KeyBlock, externTd *big.Int) error` to append key-block write operations to an existing DB batch and update in-memory td/header/block caches and heads. (core/keyblockchain.go)
- Extended `BlockChain.writeBlockWithState` to accept an optional `embeddedKey *types.KeyBlock` and, when present, enqueue the embedded key block writes into the same `blockBatch` before committing. (core/blockchain.go)
- Updated the insert flow to decode embedded key blocks prior to calling `writeBlockWithState` and removed the old post-write `InsertBlockFromData()` path. (core/blockchain.go)
- Preserved the public `WriteBlockWithState` API by forwarding to the new internal signature with `embeddedKey=nil` for backward compatibility. (core/blockchain.go)

### Testing
- Ran `go test ./core/...` in this environment but it failed due to module resolution (no main module present), so package unit tests could not be executed successfully. 
- Attempted `GO111MODULE=off GOPATH=/workspace go test ./core -run TestDoesNotExist`, which failed due to unresolved imports under the GOPATH configuration, so no automated tests in-repo passed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c56d2206d883309a5b5071752fc1d7)