### PR TITLE
Handle fake/shared PoW for key headers and defer keychain in-memory updates

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -163,6 +163,21 @@ func (ethash *Ethash) VerifyCandidate(chain types.KeyChainReader, candidate *typ
 // VerifyKeyHeaderSeal checks whether the given key block header satisfies
 // ethash PoW requirements.
 func (ethash *Ethash) VerifyKeyHeaderSeal(header *types.KeyBlockHeader) error {
+	// If we're running a fake PoW, accept any seal as valid.
+	if ethash.config.PowMode == ModeFake || ethash.config.PowMode == ModeFullFake {
+		if ethash.fakeFail == header.Number.Uint64() {
+			return errInvalidPoW
+		}
+		return nil
+	}
+	// If we're running a shared PoW, delegate verification to it if supported.
+	if ethash.shared != nil {
+		if s, ok := interface{}(ethash.shared).(interface {
+			VerifyKeyHeaderSeal(*types.KeyBlockHeader) error
+		}); ok {
+			return s.VerifyKeyHeaderSeal(header)
+		}
+	}
 	if header.Difficulty == nil || header.Difficulty.Sign() <= 0 {
 		return errInvalidDifficulty
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1486,8 +1486,9 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	rawdb.WriteBlock(blockBatch, block)
 	rawdb.WriteReceipts(blockBatch, block.Hash(), block.NumberU64(), receipts)
 	rawdb.WritePreimages(blockBatch, state.Preimages())
+	var keyExternTd *big.Int
 	if embeddedKey != nil {
-		keyExternTd, err := bc.keyBlockChain.PrepareInsert(embeddedKey)
+		keyExternTd, err = bc.keyBlockChain.PrepareInsert(embeddedKey)
 		if err != nil {
 			return NonStatTy, err
 		}
@@ -1497,6 +1498,9 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	}
 	if err := blockBatch.Write(); err != nil {
 		log.Crit("Failed to write block into disk", "err", err)
+	}
+	if embeddedKey != nil {
+		bc.keyBlockChain.ApplyPrepared(embeddedKey, keyExternTd)
 	}
 	// Commit all cached state changes into underlying memory database.
 	root, err := state.Commit(bc.chainConfig.IsEIP158(block.Number()))

--- a/core/keyblockchain.go
+++ b/core/keyblockchain.go
@@ -336,8 +336,8 @@ func (kbc *KeyBlockChain) PrepareInsert(block *types.KeyBlock) (*big.Int, error)
 	return externTd, nil
 }
 
-// InsertPrepared appends the key block write operations into batch and updates
-// in-memory key chain heads.
+// InsertPrepared appends the key block write operations into batch only.
+// In-memory heads must be updated only after the outer batch write succeeds.
 func (kbc *KeyBlockChain) InsertPrepared(batch ethdb.Batch, block *types.KeyBlock, externTd *big.Int) error {
 	if externTd == nil {
 		return nil
@@ -347,13 +347,19 @@ func (kbc *KeyBlockChain) InsertPrepared(batch ethdb.Batch, block *types.KeyBloc
 	rawdb.WriteKeyBlockHash(batch, block.Hash(), block.NumberU64())
 	rawdb.WriteHeadKeyBlockHash(batch, block.Hash())
 	rawdb.WriteHeadKeyHeaderHash(batch, block.Hash())
+	return nil
+}
 
+// ApplyPrepared updates in-memory key-chain state after the enclosing batch
+// has been durably written to disk.
+func (kbc *KeyBlockChain) ApplyPrepared(block *types.KeyBlock, externTd *big.Int) {
+	if block == nil || externTd == nil {
+		return
+	}
 	kbc.khc.tdCache.Add(block.Hash(), new(big.Int).Set(externTd))
 	kbc.blockCache.Add(block.Hash(), block)
 	kbc.currentBlock.Store(block)
-	kbc.khc.currentHeader.Store(block.Header())
-	kbc.khc.currentHeaderHash = block.Hash()
-	return nil
+	kbc.khc.SetCurrentHeader(block.Header())
 }
 
 // InsertChain attempts to insert the given batch of key blocks in to the keyblock


### PR DESCRIPTION
### Motivation
- Ensure key-block header seal verification follows the same fake/shared PoW behavior as normal headers to avoid incorrect rejections in test/fake modes.
- Prevent in-memory keychain head/cache from being updated before the enclosing DB batch is durably written to disk to avoid inconsistent state on crash or write failure.

### Description
- Add early acceptance for fake PoW modes and optional delegation to a shared PoW engine in `VerifyKeyHeaderSeal` by checking `ethash.config.PowMode` and calling a `VerifyKeyHeaderSeal` method on `ethash.shared` if implemented (file: `consensus/ethash/consensus.go`).
- Change `KeyBlockChain.InsertPrepared` to only enqueue DB writes into the provided `ethdb.Batch` and remove immediate in-memory head/cache updates (file: `core/keyblockchain.go`).
- Add `KeyBlockChain.ApplyPrepared` to update in-memory caches and current header after the outer batch has been successfully written (file: `core/keyblockchain.go`).
- Update the block write flow in `writeBlockWithState` to hold `keyExternTd` and call `ApplyPrepared` after `blockBatch.Write()` succeeds so in-memory state is applied only after durable persistence (file: `core/blockchain.go`).

### Testing
- Ran `go test ./consensus/ethash ./core`, which failed due to the environment lacking a Go module (`go: cannot find main module`) and missing external dependencies, so tests could not be executed to completion.
- Ran `GO111MODULE=off go test ./consensus/ethash ./core`, which failed due to missing GOPATH-layout dependencies and could not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c571211d048330a9fdd1dd42bf66fe)