### PR TITLE
Delay key-chain head promotion for side blocks and require shared key-seal support

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -170,13 +170,15 @@ func (ethash *Ethash) VerifyKeyHeaderSeal(header *types.KeyBlockHeader) error {
 		}
 		return nil
 	}
-	// If we're running a shared PoW, delegate verification to it if supported.
+	// If we're running a shared PoW, delegation must be supported too.
+	// Otherwise candidate verification and key-header verification can diverge.
 	if ethash.shared != nil {
 		if s, ok := interface{}(ethash.shared).(interface {
 			VerifyKeyHeaderSeal(*types.KeyBlockHeader) error
 		}); ok {
 			return s.VerifyKeyHeaderSeal(header)
 		}
+		return fmt.Errorf("shared consensus engine does not support key header seal verification")
 	}
 	if header.Difficulty == nil || header.Difficulty.Sign() <= 0 {
 		return errInvalidDifficulty

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1499,9 +1499,6 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	if err := blockBatch.Write(); err != nil {
 		log.Crit("Failed to write block into disk", "err", err)
 	}
-	if embeddedKey != nil {
-		bc.keyBlockChain.ApplyPrepared(embeddedKey, keyExternTd)
-	}
 	// Commit all cached state changes into underlying memory database.
 	root, err := state.Commit(bc.chainConfig.IsEIP158(block.Number()))
 	if err != nil {
@@ -1589,6 +1586,11 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		status = CanonStatTy
 	} else {
 		status = SideStatTy
+	}
+	if embeddedKey != nil {
+		if err := bc.keyBlockChain.ApplyPrepared(embeddedKey, keyExternTd, status == CanonStatTy); err != nil {
+			return NonStatTy, err
+		}
 	}
 	// Set new head.
 	if status == CanonStatTy {

--- a/core/keyblockchain.go
+++ b/core/keyblockchain.go
@@ -337,7 +337,8 @@ func (kbc *KeyBlockChain) PrepareInsert(block *types.KeyBlock) (*big.Int, error)
 }
 
 // InsertPrepared appends the key block write operations into batch only.
-// In-memory heads must be updated only after the outer batch write succeeds.
+// It must not advance key-chain head markers yet because the enclosing
+// normal block may still end up as a side block.
 func (kbc *KeyBlockChain) InsertPrepared(batch ethdb.Batch, block *types.KeyBlock, externTd *big.Int) error {
 	if externTd == nil {
 		return nil
@@ -345,21 +346,32 @@ func (kbc *KeyBlockChain) InsertPrepared(batch ethdb.Batch, block *types.KeyBloc
 	rawdb.WriteTd(batch, block.Hash(), block.NumberU64(), externTd)
 	rawdb.WriteKeyBlock(batch, block)
 	rawdb.WriteKeyBlockHash(batch, block.Hash(), block.NumberU64())
-	rawdb.WriteHeadKeyBlockHash(batch, block.Hash())
-	rawdb.WriteHeadKeyHeaderHash(batch, block.Hash())
 	return nil
 }
 
-// ApplyPrepared updates in-memory key-chain state after the enclosing batch
-// has been durably written to disk.
-func (kbc *KeyBlockChain) ApplyPrepared(block *types.KeyBlock, externTd *big.Int) {
+// ApplyPrepared updates caches after the enclosing batch has been durably written
+// to disk. Head markers are only advanced when promoteHead is true.
+func (kbc *KeyBlockChain) ApplyPrepared(block *types.KeyBlock, externTd *big.Int, promoteHead bool) error {
 	if block == nil || externTd == nil {
-		return
+		return nil
 	}
 	kbc.khc.tdCache.Add(block.Hash(), new(big.Int).Set(externTd))
 	kbc.blockCache.Add(block.Hash(), block)
+
+	if !promoteHead {
+		return nil
+	}
+
+	batch := kbc.db.NewBatch()
+	rawdb.WriteHeadKeyBlockHash(batch, block.Hash())
+	rawdb.WriteHeadKeyHeaderHash(batch, block.Hash())
+	if err := batch.Write(); err != nil {
+		return err
+	}
+
 	kbc.currentBlock.Store(block)
 	kbc.khc.SetCurrentHeader(block.Header())
+	return nil
 }
 
 // InsertChain attempts to insert the given batch of key blocks in to the keyblock


### PR DESCRIPTION
### Motivation
- Prevent the key-chain head from being advanced while writing staged key-blocks that may become side blocks, which can corrupt head markers if the enclosing normal block is not canonical.
- Avoid divergent verification paths between candidate verification and key-header verification when using a shared PoW engine by ensuring the shared engine actually implements key-header seal checks.

### Description
- Tighten `Ethash.VerifyKeyHeaderSeal` to return an explicit error when a configured `shared` consensus engine does not implement `VerifyKeyHeaderSeal`, preventing silent divergence in verification behavior (`consensus/ethash/consensus.go`).
- Stop `KeyBlockChain.InsertPrepared` from writing head marker keys into the batch to avoid prematurely advancing key-chain heads during block staging (`core/keyblockchain.go`).
- Change `KeyBlockChain.ApplyPrepared` to accept a `promoteHead bool`, always refresh caches after durable writes, only persist and promote head markers when `promoteHead` is true, and return any write error (`core/keyblockchain.go`).
- Update `BlockChain.writeBlockWithState` to defer calling `ApplyPrepared` until after canonical/side status is decided and to propagate errors from `ApplyPrepared` (`core/blockchain.go`).

### Testing
- Ran `gofmt -w` on the modified files to ensure formatting, which completed successfully.
- Tried `go test ./consensus/ethash ./core` but it failed due to the environment not being set up as a Go module (`cannot find main module`).
- Tried `GO111MODULE=off go test ./consensus/ethash ./core` but package resolution failed in this environment due to missing GOPATH/module dependencies, so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c575661afc833099e69165d65a7c8f)