### PR TITLE
Defer canonical key-block hash writes until prepared block promotion

### DIFF
--- a/core/keyblockchain.go
+++ b/core/keyblockchain.go
@@ -345,12 +345,11 @@ func (kbc *KeyBlockChain) InsertPrepared(batch ethdb.Batch, block *types.KeyBloc
 	}
 	rawdb.WriteTd(batch, block.Hash(), block.NumberU64(), externTd)
 	rawdb.WriteKeyBlock(batch, block)
-	rawdb.WriteKeyBlockHash(batch, block.Hash(), block.NumberU64())
 	return nil
 }
 
 // ApplyPrepared updates caches after the enclosing batch has been durably written
-// to disk. Head markers are only advanced when promoteHead is true.
+// to disk. Canonical key-chain markers are only advanced when promoteHead is true.
 func (kbc *KeyBlockChain) ApplyPrepared(block *types.KeyBlock, externTd *big.Int, promoteHead bool) error {
 	if block == nil || externTd == nil {
 		return nil
@@ -363,6 +362,7 @@ func (kbc *KeyBlockChain) ApplyPrepared(block *types.KeyBlock, externTd *big.Int
 	}
 
 	batch := kbc.db.NewBatch()
+	rawdb.WriteKeyBlockHash(batch, block.Hash(), block.NumberU64())
 	rawdb.WriteHeadKeyBlockHash(batch, block.Hash())
 	rawdb.WriteHeadKeyHeaderHash(batch, block.Hash())
 	if err := batch.Write(); err != nil {


### PR DESCRIPTION
### Motivation
- Avoid marking prepared key blocks as canonical before the enclosing normal block is accepted by deferring the canonical number→hash mapping until the prepared block is promoted.

### Description
- Removed `rawdb.WriteKeyBlockHash` from `InsertPrepared`, added `rawdb.WriteKeyBlockHash` into `ApplyPrepared` only when `promoteHead` is true, and clarified the `ApplyPrepared` comment to mention canonical marker promotion.

### Testing
- Ran `go test ./core/...` which failed in this environment with `directory prefix core does not contain main module or its selected dependencies`, so automated tests could not be executed successfully here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c57760f5c4833093abef2d1322d0e4)