### PR TITLE
ethash: use Colossus hashing for key-header verification and candidate mining

### DIFF
--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -161,7 +161,7 @@ func (ethash *Ethash) VerifyCandidate(chain types.KeyChainReader, candidate *typ
 }
 
 // VerifyKeyHeaderSeal checks whether the given key block header satisfies
-// ethash PoW requirements.
+// the key-block Colossus PoW requirements.
 func (ethash *Ethash) VerifyKeyHeaderSeal(header *types.KeyBlockHeader) error {
 	// If we're running a fake PoW, accept any seal as valid.
 	if ethash.config.PowMode == ModeFake || ethash.config.PowMode == ModeFullFake {
@@ -191,9 +191,9 @@ func (ethash *Ethash) VerifyKeyHeaderSeal(header *types.KeyBlockHeader) error {
 	if ethash.config.PowMode == ModeTest {
 		size = 32 * 1024
 	}
-	digest, result := hashimotoLight(size, cache.cache, header.SealHash().Bytes(), header.Nonce.Uint64())
+	digest, result := colossusHashLight(size, cache.cache, header.SealHash().Bytes(), header.Nonce.Uint64())
 	// Caches are unmapped in a finalizer. Ensure that the cache stays live
-	// until after the call to hashimotoLight so it's not unmapped while being used.
+	// until after the call to colossusHashLight so it's not unmapped while being used.
 	runtime.KeepAlive(cache)
 
 	if !bytes.Equal(header.MixDigest[:], digest) {

--- a/consensus/ethash/sealer.go
+++ b/consensus/ethash/sealer.go
@@ -92,8 +92,8 @@ func (ethash *Ethash) SealCandidate(candidate *types.Candidate, stop <-chan stru
 	return result, nil
 }
 
-// mineCandidate is the actual proof-of-work miner that searches for a nonce starting from
-// seed that results in correct final block difficulty.
+// mineCandidate is the actual key-block Colossus proof-of-work miner that
+// searches for a nonce starting from seed that results in correct final block difficulty.
 func (ethash *Ethash) mineCandidate(candidate *types.Candidate, id int, seed uint64, abort chan struct{}, found chan *types.Candidate) {
 	// Extract some data from the header
 	var (
@@ -126,7 +126,7 @@ search:
 				attempts = 0
 			}
 			// Compute the PoW value of this nonce
-			digest, result := hashimotoFull(dataset.dataset, hash, nonce)
+			digest, result := colossusHashFull(dataset.dataset, hash, nonce)
 
 			if new(big.Int).SetBytes(result).Cmp(target) <= 0 {
 				foundedTime := time.Now().Unix()


### PR DESCRIPTION
### Motivation
- Align key-block proof-of-work verification and mining with the Colossus hashing functions instead of the legacy Hashimoto implementation to reflect protocol/algorithm changes.
- Update comments and terminology to explicitly reference key-block Colossus PoW for clarity.

### Description
- Replace `hashimotoLight` with `colossusHashLight` in `VerifyKeyHeaderSeal` to compute key-header digest and PoW result in `consensus/ethash/consensus.go`.
- Update the adjacent cache-lifetime comment to reference `colossusHashLight` in `consensus/ethash/consensus.go`.
- Replace `hashimotoFull` with `colossusHashFull` in the nonce evaluation loop within `mineCandidate` in `consensus/ethash/sealer.go`.
- Refresh `VerifyKeyHeaderSeal` and `mineCandidate` comments to reference key-block Colossus PoW terminology in the two modified files.

### Testing
- Ran `go test ./consensus/ethash`, which failed due to repository layout lacking a Go module root (error: "cannot find main module").
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5928b49448330b7d1e78370304ce3)