### PR TITLE
ethash: reuse colossus scratchpad buffers

### DIFF
--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -61,6 +61,23 @@ const (
 	colossusDomainTag       = "COLXH1"
 )
 
+var colossusScratchpadPool = sync.Pool{
+	New: func() interface{} {
+		return make([]uint32, colossusScratchpadWords)
+	},
+}
+
+func colossusAcquireScratchpad() []uint32 {
+	return colossusScratchpadPool.Get().([]uint32)
+}
+
+func colossusReleaseScratchpad(scratchpad []uint32) {
+	if cap(scratchpad) < colossusScratchpadWords {
+		return
+	}
+	colossusScratchpadPool.Put(scratchpad[:colossusScratchpadWords])
+}
+
 // cacheSize returns the size of the ethash verification cache that belongs to a certain
 // block number.
 func cacheSize(block uint64) uint64 {
@@ -468,7 +485,7 @@ func colossusLookupPageLight(cache []uint32, pageIndex uint32, keccak512 hasher,
 	}
 }
 
-func colossusHashCore(numPages uint32, sealHash []byte, nonce uint64, pageLookup func(pageIndex uint32, out *[colossusPageWords]uint32)) ([]byte, []byte) {
+func colossusHashCoreWithScratchpad(scratchpad []uint32, numPages uint32, sealHash []byte, nonce uint64, pageLookup func(pageIndex uint32, out *[colossusPageWords]uint32)) ([]byte, []byte) {
 	nonceLE := colossusNonceLE(nonce)
 	seed := crypto.Keccak512([]byte(colossusDomainTag), sealHash, nonceLE[:])
 
@@ -478,7 +495,7 @@ func colossusHashCore(numPages uint32, sealHash []byte, nonce uint64, pageLookup
 		acc[i] = state[i] ^ state[i+colossusAccWords]
 	}
 
-	scratchpad := make([]uint32, colossusScratchpadWords)
+	scratchpad = scratchpad[:colossusScratchpadWords]
 	for k := uint32(0); k < colossusScratchpadWords; k++ {
 		idx := k % colossusStateWords
 		x := state[idx]
@@ -540,20 +557,34 @@ func colossusHashCore(numPages uint32, sealHash []byte, nonce uint64, pageLookup
 	return mixDigest, result
 }
 
-func colossusHashLight(size uint64, cache []uint32, sealHash []byte, nonce uint64) ([]byte, []byte) {
+func colossusHashLightWithScratchpad(scratchpad []uint32, size uint64, cache []uint32, sealHash []byte, nonce uint64) ([]byte, []byte) {
 	numPages := colossusNumPages(size)
 	keccak512 := makeHasher(sha3.NewLegacyKeccak512())
-	return colossusHashCore(numPages, sealHash, nonce, func(pageIndex uint32, out *[colossusPageWords]uint32) {
+	return colossusHashCoreWithScratchpad(scratchpad, numPages, sealHash, nonce, func(pageIndex uint32, out *[colossusPageWords]uint32) {
 		colossusLookupPageLight(cache, pageIndex, keccak512, out)
 	})
 }
 
-func colossusHashFull(dataset []uint32, sealHash []byte, nonce uint64) ([]byte, []byte) {
+func colossusHashLight(size uint64, cache []uint32, sealHash []byte, nonce uint64) ([]byte, []byte) {
+	scratchpad := colossusAcquireScratchpad()
+	defer colossusReleaseScratchpad(scratchpad)
+
+	return colossusHashLightWithScratchpad(scratchpad, size, cache, sealHash, nonce)
+}
+
+func colossusHashFullWithScratchpad(scratchpad []uint32, dataset []uint32, sealHash []byte, nonce uint64) ([]byte, []byte) {
 	datasetWords := len(dataset) - (len(dataset) % colossusPageWords)
 	numPages := uint32(datasetWords / colossusPageWords)
-	return colossusHashCore(numPages, sealHash, nonce, func(pageIndex uint32, out *[colossusPageWords]uint32) {
+	return colossusHashCoreWithScratchpad(scratchpad, numPages, sealHash, nonce, func(pageIndex uint32, out *[colossusPageWords]uint32) {
 		colossusLookupPageFull(dataset[:datasetWords], pageIndex, out)
 	})
+}
+
+func colossusHashFull(dataset []uint32, sealHash []byte, nonce uint64) ([]byte, []byte) {
+	scratchpad := colossusAcquireScratchpad()
+	defer colossusReleaseScratchpad(scratchpad)
+
+	return colossusHashFullWithScratchpad(scratchpad, dataset, sealHash, nonce)
 }
 
 // maxEpoch bounds the pre-generated future cache/dataset epoch in the LRU.

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -264,6 +264,8 @@ func (ethash *Ethash) SealHeader(header *types.Header, stop <-chan struct{}) err
 	hash := header.SealHash().Bytes()
 	dataset := ethash.dataset(number)
 	defer runtime.KeepAlive(dataset)
+	scratchpad := colossusAcquireScratchpad()
+	defer colossusReleaseScratchpad(scratchpad)
 
 	for nonce := uint64(0); ; nonce++ {
 		select {
@@ -271,7 +273,7 @@ func (ethash *Ethash) SealHeader(header *types.Header, stop <-chan struct{}) err
 			return errors.New("sealing aborted")
 		default:
 		}
-		digest, result := colossusHashFull(dataset.dataset, hash, nonce)
+		digest, result := colossusHashFullWithScratchpad(scratchpad, dataset.dataset, hash, nonce)
 		if new(big.Int).SetBytes(result).Cmp(target) <= 0 {
 			header.Nonce = types.EncodeNonce(nonce)
 			header.MixDigest = common.BytesToHash(digest)

--- a/consensus/ethash/sealer.go
+++ b/consensus/ethash/sealer.go
@@ -97,11 +97,13 @@ func (ethash *Ethash) SealCandidate(candidate *types.Candidate, stop <-chan stru
 func (ethash *Ethash) mineCandidate(candidate *types.Candidate, id int, seed uint64, abort chan struct{}, found chan *types.Candidate) {
 	// Extract some data from the header
 	var (
-		hash    = candidate.KeyCandidate.SealHash().Bytes()
-		target  = new(big.Int).Div(maxUint256, candidate.KeyCandidate.Difficulty)
-		number  = candidate.KeyCandidate.Number.Uint64()
-		dataset = ethash.dataset(number)
+		hash       = candidate.KeyCandidate.SealHash().Bytes()
+		target     = new(big.Int).Div(maxUint256, candidate.KeyCandidate.Difficulty)
+		number     = candidate.KeyCandidate.Number.Uint64()
+		dataset    = ethash.dataset(number)
+		scratchpad = colossusAcquireScratchpad()
 	)
+	defer colossusReleaseScratchpad(scratchpad)
 	// Start generating random nonces until we abort or find a good one
 	var (
 		attempts = int64(0)
@@ -126,7 +128,7 @@ search:
 				attempts = 0
 			}
 			// Compute the PoW value of this nonce
-			digest, result := colossusHashFull(dataset.dataset, hash, nonce)
+			digest, result := colossusHashFullWithScratchpad(scratchpad, dataset.dataset, hash, nonce)
 
 			if new(big.Int).SetBytes(result).Cmp(target) <= 0 {
 				foundedTime := time.Now().Unix()


### PR DESCRIPTION
### Motivation

- Reduce repeated large allocations and GC pressure from allocating an 8MB Colossus scratchpad for every hash invocation by reusing buffers across calls and miner threads.

### Description

- Add a shared `sync.Pool` (`colossusScratchpadPool`) and helper functions `colossusAcquireScratchpad` / `colossusReleaseScratchpad` to allocate and return `[]uint32` scratchpads.
- Introduce scratchpad-aware hashing entrypoints `colossusHashCoreWithScratchpad`, `colossusHashLightWithScratchpad`, and `colossusHashFullWithScratchpad` and keep existing `colossusHashLight` / `colossusHashFull` as wrappers that acquire/release pooled buffers.
- Update sealing hot paths to reuse a single scratchpad per sealing context by calling the `*WithScratchpad` variants from `SealHeader` and per-miner worker in `mineCandidate` to avoid per-nonce allocations.
- Add a capacity check on release to avoid putting undersized slices back into the pool and slice to fixed length on acquire to ensure expected capacity.

### Testing

- Ran code formatting with `gofmt -w consensus/ethash/algorithm.go consensus/ethash/consensus.go consensus/ethash/sealer.go`, which completed successfully. 
- Ran `go test ./consensus/ethash`, which could not run in this environment due to the repository not being a Go module (`go: cannot find main module`), so package tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c596ac53a883308239ea3080290a1b)