### PR TITLE
Add consensus/colossusx compatibility package and migrate imports

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -36,7 +36,7 @@ import (
 	"github.com/cypherium/cypher/accounts/keystore"
 	"github.com/cypherium/cypher/common"
 	"github.com/cypherium/cypher/common/fdlimit"
-	"github.com/cypherium/cypher/consensus/ethash"
+	"github.com/cypherium/cypher/consensus/colossusx"
 	"github.com/cypherium/cypher/core"
 	"github.com/cypherium/cypher/core/rawdb"
 	"github.com/cypherium/cypher/core/vm"
@@ -1880,7 +1880,7 @@ func MakeChain(ctx *cli.Context, stack *node.Node, readOnly bool, useExist bool)
 		}
 	}
 
-	engine := ethash.NewFullFaker()
+	engine := colossusx.NewFullFaker()
 	if gcmode := ctx.GlobalString(GCModeFlag.Name); gcmode != "full" && gcmode != "archive" {
 		Fatalf("--%s must be either 'full' or 'archive'", GCModeFlag.Name)
 	}

--- a/consensus/colossusx/alias.go
+++ b/consensus/colossusx/alias.go
@@ -1,0 +1,68 @@
+// Package colossusx is a compatibility-first staging package for the UMA-PoW
+// engine. It re-exports the current implementation from consensus/ethash so
+// the rest of the codebase can migrate imports and runtime wiring first,
+// before moving the implementation files themselves.
+package colossusx
+
+import (
+	"time"
+
+	"github.com/cypherium/cypher/consensus/ethash"
+)
+
+type (
+	Mode      = ethash.Mode
+	Config    = ethash.Config
+	ColossusX = ethash.Ethash
+)
+
+const (
+	ModeNormal    = ethash.ModeNormal
+	ModeShared    = ethash.ModeShared
+	ModeTest      = ethash.ModeTest
+	ModeFake      = ethash.ModeFake
+	ModeFullFake  = ethash.ModeFullFake
+	ModeLocalMock = ethash.ModeLocalMock
+)
+
+var ErrInvalidDumpMagic = ethash.ErrInvalidDumpMagic
+
+func New(config Config) *ColossusX {
+	return ethash.New(config)
+}
+
+func NewTester() *ColossusX {
+	return ethash.NewTester()
+}
+
+func NewFaker() *ColossusX {
+	return ethash.NewFaker()
+}
+
+func NewFakeFailer(fail uint64) *ColossusX {
+	return ethash.NewFakeFailer(fail)
+}
+
+func NewFakeDelayer(delay time.Duration) *ColossusX {
+	return ethash.NewFakeDelayer(delay)
+}
+
+func NewFullFaker() *ColossusX {
+	return ethash.NewFullFaker()
+}
+
+func NewNormal() *ColossusX {
+	return ethash.NewNormal()
+}
+
+func MakeCache(block uint64, dir string) {
+	ethash.MakeCache(block, dir)
+}
+
+func MakeDataset(block uint64, dir string) {
+	ethash.MakeDataset(block, dir)
+}
+
+func SeedHash(block uint64) []byte {
+	return ethash.SeedHash(block)
+}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cypherium/cypher/common"
 	"github.com/cypherium/cypher/common/hexutil"
 	"github.com/cypherium/cypher/consensus"
-	"github.com/cypherium/cypher/consensus/ethash"
+	"github.com/cypherium/cypher/consensus/colossusx"
 
 	"github.com/cypherium/cypher/core"
 	"github.com/cypherium/cypher/core/bloombits"
@@ -285,7 +285,7 @@ func makeExtraData(extra []byte, hasPrivate bool) []byte {
 // CreateConsensusEngine creates the required type of consensus engine instance for an Ethereum service
 func CreateConsensusEngine(stack *node.Node, chainConfig *params.ChainConfig, config *Config) consensus.Engine {
 	s := config.Ethash
-	engine := ethash.New(ethash.Config{
+	engine := colossusx.New(colossusx.Config{
 		CacheDir:       stack.ResolvePath(s.CacheDir),
 		CachesInMem:    s.CachesInMem,
 		CachesOnDisk:   s.CachesOnDisk,
@@ -293,7 +293,7 @@ func CreateConsensusEngine(stack *node.Node, chainConfig *params.ChainConfig, co
 		DatasetsInMem:  s.DatasetsInMem,
 		DatasetsOnDisk: s.DatasetsOnDisk,
 	})
-	//	engine := ethash.NewNormal()
+	//	engine := colossusx.NewNormal()
 	engine.SetThreads(-1) // Disable CPU mining
 	return engine
 }

--- a/eth/config.go
+++ b/eth/config.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/cypherium/cypher/common"
-	"github.com/cypherium/cypher/consensus/ethash"
+	"github.com/cypherium/cypher/consensus/colossusx"
 	"github.com/cypherium/cypher/core"
 	"github.com/cypherium/cypher/eth/downloader"
 	"github.com/cypherium/cypher/eth/gasprice"
@@ -48,7 +48,7 @@ var DefaultLightGPOConfig = gasprice.Config{
 // DefaultConfig contains default settings for use on the Ethereum main net.
 var DefaultConfig = Config{
 	SyncMode: downloader.FastSync,
-	Ethash: ethash.Config{
+	Ethash: colossusx.Config{
 		CacheDir:         "ethash",
 		CachesInMem:      2,
 		CachesOnDisk:     3,
@@ -152,8 +152,9 @@ type Config struct {
 	// Mining options
 	Miner miner.Config
 
-	// Ethash options
-	Ethash ethash.Config
+	// Ethash-named config field kept for compatibility during the first
+	// split, but the concrete type now comes from consensus/colossusx.
+	Ethash colossusx.Config
 
 	// Transaction pool options
 	TxPool core.TxPoolConfig

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cypherium/cypher/reconfig/bftview"
 
 	"github.com/cypherium/cypher/consensus"
-	"github.com/cypherium/cypher/consensus/ethash"
+	"github.com/cypherium/cypher/consensus/colossusx"
 	"github.com/cypherium/cypher/ethdb"
 	"github.com/cypherium/cypher/event"
 	"github.com/cypherium/cypher/log"
@@ -242,7 +242,7 @@ func (self *worker) wait() {
 				}
 			}
 
-			if ethash.Mode(self.engine.PowMode()) == ethash.ModeLocalMock {
+			if colossusx.Mode(self.engine.PowMode()) == colossusx.ModeLocalMock {
 				self.LocalMockAutoTrigNextTermPow(candidate)
 			}
 
@@ -286,7 +286,7 @@ func (self *worker) commitNewWork() {
 		log.Error("worker.commitNewWork is too low", "number", txBlock.NumberU64())
 		return
 	}
-	if ethash.Mode(self.engine.PowMode()) != ethash.ModeLocalMock {
+	if colossusx.Mode(self.engine.PowMode()) != colossusx.ModeLocalMock {
 		if self.candidatePool.FoundCandidate(keyBlock.Number(), string(self.pubKey)) {
 			log.Trace("Found existing candidate of head key block")
 			return


### PR DESCRIPTION
### Motivation
- Prepare a staged rename / split of the UMA-PoW engine by introducing a thin compatibility package so imports and wiring can migrate before moving implementation files. 
- Allow code to switch to the new package while preserving existing configuration and CLI flag names for backward compatibility. 

### Description
- Add `consensus/colossusx/alias.go` which thinly re-exports `consensus/ethash` types, constants, constructors, and helper functions (e.g. `Mode`, `Config`, `Ethash` alias, `New`, `NewFullFaker`, `NewNormal`, `MakeCache`, `MakeDataset`, `SeedHash`).
- Switch confirmed imports in runtime/config/CLI/miner code from `github.com/cypherium/cypher/consensus/ethash` to `github.com/cypherium/cypher/consensus/colossusx` in `eth/config.go`, `eth/backend.go`, `cmd/utils/flags.go`, and `miner/worker.go`.
- Preserve the public field name `Config.Ethash` for compatibility while making its concrete type `colossusx.Config` so existing config/flag names remain unchanged.
- Update runtime references to use `colossusx.Mode(...)` and the `colossusx` constructors where appropriate (for example `colossusx.NewFullFaker()` and `colossusx.New(...)`).

### Testing
- Ran `go test ./consensus/colossusx ./eth ./miner ./cmd/utils` in this environment, which failed with `cannot find main module` because the container is not configured as a Go module workspace.
- Ran `GO111MODULE=off go test ./consensus/colossusx ./eth ./miner ./cmd/utils`, which failed due to GOPATH/workspace resolution (imports like `github.com/cypherium/cypher/...` are not resolvable in this container).
- Recommendation: run the full test suite and a `go build` in a proper Go module or GOPATH workspace locally or in CI to validate compilation and runtime behavior (these changes are mechanical import/type alias changes and should compile in a correctly configured Go environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c59b34755483308b4278c3daf8428e)