### PR TITLE
Copy ethash implementation files into consensus/colossusx

### DIFF
--- a/consensus/colossusx/algorithm.go
+++ b/consensus/colossusx/algorithm.go
@@ -1,0 +1,591 @@
+// Copyright 2017 The cypherBFT Authors
+// This file is part of the cypherBFT library.
+//
+// The cypherBFT library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The cypherBFT library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the cypherBFT library. If not, see <http://www.gnu.org/licenses/>.
+
+package ethash
+
+import (
+	"encoding/binary"
+	"hash"
+	"math/big"
+	"reflect"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"github.com/cypherium/cypher/common"
+	"github.com/cypherium/cypher/common/bitutil"
+	"github.com/cypherium/cypher/crypto"
+	"github.com/cypherium/cypher/log"
+	"golang.org/x/crypto/sha3"
+)
+
+const (
+	datasetInitBytes   = 1 << 32 // Bytes in dataset at genesis
+	datasetGrowthBytes = 1 << 23 // Dataset growth per epoch
+	cacheInitBytes     = 1 << 26 // Bytes in cache at genesis
+	cacheGrowthBytes   = 1 << 17 // Cache growth per epoch
+	epochLength        = 30000   // Blocks per epoch
+	mixBytes           = 128     // Width of mix
+	hashBytes          = 64      // Hash length in bytes
+	hashWords          = 16      // Number of 32 bit ints in a hash
+	datasetParents     = 256     // Number of parents of each dataset element
+	cacheRounds        = 3       // Number of rounds in cache production
+	loopAccesses       = 64      // Number of accesses in hashimoto loop
+
+	colossusPageBytes       = 512
+	colossusTileBytes       = 512
+	colossusScratchpadBytes = 8 * 1024 * 1024
+	colossusScratchpadWords = colossusScratchpadBytes / 4
+	colossusPageWords       = colossusPageBytes / 4
+	colossusTileWords       = colossusTileBytes / 4
+	colossusNumTiles        = colossusScratchpadBytes / colossusTileBytes
+	colossusRounds          = 64
+	colossusInternalPasses  = 4
+	colossusStateWords      = 16
+	colossusAccWords        = 8
+	colossusDomainTag       = "COLXH1"
+)
+
+var colossusScratchpadPool = sync.Pool{
+	New: func() interface{} {
+		return make([]uint32, colossusScratchpadWords)
+	},
+}
+
+func colossusAcquireScratchpad() []uint32 {
+	return colossusScratchpadPool.Get().([]uint32)
+}
+
+func colossusReleaseScratchpad(scratchpad []uint32) {
+	if cap(scratchpad) < colossusScratchpadWords {
+		return
+	}
+	colossusScratchpadPool.Put(scratchpad[:colossusScratchpadWords])
+}
+
+// cacheSize returns the size of the ethash verification cache that belongs to a certain
+// block number.
+func cacheSize(block uint64) uint64 {
+	return calcCacheSize(int(block / epochLength))
+}
+
+// calcCacheSize calculates the cache size for epoch. The cache size grows linearly,
+// however, we always take the highest prime below the linearly growing threshold in order
+// to reduce the risk of accidental regularities leading to cyclic behavior.
+func calcCacheSize(epoch int) uint64 {
+	size := cacheInitBytes + cacheGrowthBytes*uint64(epoch) - hashBytes
+	for !new(big.Int).SetUint64(size / hashBytes).ProbablyPrime(1) { // Always accurate for n < 2^64
+		size -= 2 * hashBytes
+	}
+	return size
+}
+
+// datasetSize returns the size of the ethash mining dataset that belongs to a certain
+// block number.
+func datasetSize(block uint64) uint64 {
+	return calcDatasetSize(int(block / epochLength))
+}
+
+// calcDatasetSize calculates the dataset size for epoch. The dataset size grows linearly,
+// however, we always take the highest prime below the linearly growing threshold in order
+// to reduce the risk of accidental regularities leading to cyclic behavior.
+func calcDatasetSize(epoch int) uint64 {
+	size := datasetInitBytes + datasetGrowthBytes*uint64(epoch) - mixBytes
+	for !new(big.Int).SetUint64(size / mixBytes).ProbablyPrime(1) { // Always accurate for n < 2^64
+		size -= 2 * mixBytes
+	}
+	return size
+}
+
+// hasher is a repetitive hasher allowing the same hash data structures to be
+// reused between hash runs instead of requiring new ones to be created.
+type hasher func(dest []byte, data []byte)
+
+// makeHasher creates a repetitive hasher, allowing the same hash data structures to
+// be reused between hash runs instead of requiring new ones to be created. The returned
+// function is not thread safe!
+func makeHasher(h hash.Hash) hasher {
+	// sha3.state supports Read to get the sum, use it to avoid the overhead of Sum.
+	// Read alters the state but we reset the hash before every operation.
+	type readerHash interface {
+		hash.Hash
+		Read([]byte) (int, error)
+	}
+	rh, ok := h.(readerHash)
+	if !ok {
+		panic("can't find Read method on hash")
+	}
+	outputLen := rh.Size()
+	return func(dest []byte, data []byte) {
+		rh.Reset()
+		rh.Write(data)
+		rh.Read(dest[:outputLen])
+	}
+}
+
+// seedHash is the seed to use for generating a verification cache and the mining
+// dataset.
+func seedHash(block uint64) []byte {
+	seed := make([]byte, 32)
+	if block < epochLength {
+		return seed
+	}
+	keccak256 := makeHasher(sha3.NewLegacyKeccak256())
+	for i := 0; i < int(block/epochLength); i++ {
+		keccak256(seed, seed)
+	}
+	return seed
+}
+
+// generateCache creates a verification cache of a given size for an input seed.
+// The cache production process involves first sequentially filling up 32 MB of
+// memory, then performing two passes of Sergio Demian Lerner's RandMemoHash
+// algorithm from Strict Memory Hard Hashing Functions (2014). The output is a
+// set of 524288 64-byte values.
+// This method places the result into dest in machine byte order.
+func generateCache(dest []uint32, epoch uint64, seed []byte) {
+	// Print some debug logs to allow analysis on low end devices
+	logger := log.New("epoch", epoch)
+
+	start := time.Now()
+	defer func() {
+		elapsed := time.Since(start)
+
+		logFn := logger.Debug
+		if elapsed > 3*time.Second {
+			logFn = logger.Info
+		}
+		logFn("Generated ethash verification cache", "elapsed", common.PrettyDuration(elapsed))
+	}()
+	// Convert our destination slice to a byte buffer
+	header := *(*reflect.SliceHeader)(unsafe.Pointer(&dest))
+	header.Len *= 4
+	header.Cap *= 4
+	cache := *(*[]byte)(unsafe.Pointer(&header))
+
+	// Calculate the number of theoretical rows (we'll store in one buffer nonetheless)
+	size := uint64(len(cache))
+	rows := int(size) / hashBytes
+
+	// Start a monitoring goroutine to report progress on low end devices
+	var progress uint32
+
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-time.After(3 * time.Second):
+				logger.Info("Generating ethash verification cache", "percentage", atomic.LoadUint32(&progress)*100/uint32(rows)/4, "elapsed", common.PrettyDuration(time.Since(start)))
+			}
+		}
+	}()
+	// Create a hasher to reuse between invocations
+	keccak512 := makeHasher(sha3.NewLegacyKeccak512())
+
+	// Sequentially produce the initial dataset
+	keccak512(cache, seed)
+	for offset := uint64(hashBytes); offset < size; offset += hashBytes {
+		keccak512(cache[offset:], cache[offset-hashBytes:offset])
+		atomic.AddUint32(&progress, 1)
+	}
+	// Use a low-round version of randmemohash
+	temp := make([]byte, hashBytes)
+
+	for i := 0; i < cacheRounds; i++ {
+		for j := 0; j < rows; j++ {
+			var (
+				srcOff = ((j - 1 + rows) % rows) * hashBytes
+				dstOff = j * hashBytes
+				xorOff = (binary.LittleEndian.Uint32(cache[dstOff:]) % uint32(rows)) * hashBytes
+			)
+			bitutil.XORBytes(temp, cache[srcOff:srcOff+hashBytes], cache[xorOff:xorOff+hashBytes])
+			keccak512(cache[dstOff:], temp)
+
+			atomic.AddUint32(&progress, 1)
+		}
+	}
+	// Swap the byte order on big endian systems and return
+	if !isLittleEndian() {
+		swap(cache)
+	}
+}
+
+// swap changes the byte order of the buffer assuming a uint32 representation.
+func swap(buffer []byte) {
+	for i := 0; i < len(buffer); i += 4 {
+		binary.BigEndian.PutUint32(buffer[i:], binary.LittleEndian.Uint32(buffer[i:]))
+	}
+}
+
+// prepare converts an ethash cache or dataset from a byte stream into the internal
+// int representation. All ethash methods work with ints to avoid constant byte to
+// int conversions as well as to handle both little and big endian systems.
+func prepare(dest []uint32, src []byte) {
+	for i := 0; i < len(dest); i++ {
+		dest[i] = binary.LittleEndian.Uint32(src[i*4:])
+	}
+}
+
+// fnv is an algorithm inspired by the FNV hash, which in some cases is used as
+// a non-associative substitute for XOR. Note that we multiply the prime with
+// the full 32-bit input, in contrast with the FNV-1 spec which multiplies the
+// prime with one byte (octet) in turn.
+func fnv(a, b uint32) uint32 {
+	return a*0x01000193 ^ b
+}
+
+// fnvHash mixes in data into mix using the ethash fnv method.
+func fnvHash(mix []uint32, data []uint32) {
+	for i := 0; i < len(mix); i++ {
+		mix[i] = mix[i]*0x01000193 ^ data[i]
+	}
+}
+
+// generateDatasetItem combines data from 256 pseudorandomly selected cache nodes,
+// and hashes that to compute a single dataset node.
+func generateDatasetItem(cache []uint32, index uint32, keccak512 hasher) []byte {
+	// Calculate the number of theoretical rows (we use one buffer nonetheless)
+	rows := uint32(len(cache) / hashWords)
+
+	// Initialize the mix
+	mix := make([]byte, hashBytes)
+
+	binary.LittleEndian.PutUint32(mix, cache[(index%rows)*hashWords]^index)
+	for i := 1; i < hashWords; i++ {
+		binary.LittleEndian.PutUint32(mix[i*4:], cache[(index%rows)*hashWords+uint32(i)])
+	}
+	keccak512(mix, mix)
+
+	// Convert the mix to uint32s to avoid constant bit shifting
+	intMix := make([]uint32, hashWords)
+	for i := 0; i < len(intMix); i++ {
+		intMix[i] = binary.LittleEndian.Uint32(mix[i*4:])
+	}
+	// fnv it with a lot of random cache nodes based on index
+	for i := uint32(0); i < datasetParents; i++ {
+		parent := fnv(index^i, intMix[i%16]) % rows
+		fnvHash(intMix, cache[parent*hashWords:])
+	}
+	// Flatten the uint32 mix into a binary one and return
+	for i, val := range intMix {
+		binary.LittleEndian.PutUint32(mix[i*4:], val)
+	}
+	keccak512(mix, mix)
+	return mix
+}
+
+// generateDataset generates the entire ethash dataset for mining.
+// This method places the result into dest in machine byte order.
+func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
+	// Print some debug logs to allow analysis on low end devices
+	logger := log.New("epoch", epoch)
+
+	start := time.Now()
+	defer func() {
+		elapsed := time.Since(start)
+
+		logFn := logger.Debug
+		if elapsed > 3*time.Second {
+			logFn = logger.Info
+		}
+		logFn("Generated ethash verification cache", "elapsed", common.PrettyDuration(elapsed))
+	}()
+
+	// Figure out whether the bytes need to be swapped for the machine
+	swapped := !isLittleEndian()
+
+	// Convert our destination slice to a byte buffer
+	header := *(*reflect.SliceHeader)(unsafe.Pointer(&dest))
+	header.Len *= 4
+	header.Cap *= 4
+	dataset := *(*[]byte)(unsafe.Pointer(&header))
+
+	// Generate the dataset on many goroutines since it takes a while
+	threads := runtime.NumCPU()
+	size := uint64(len(dataset))
+
+	var pend sync.WaitGroup
+	pend.Add(threads)
+
+	var progress uint32
+	for i := 0; i < threads; i++ {
+		go func(id int) {
+			defer pend.Done()
+
+			// Create a hasher to reuse between invocations
+			keccak512 := makeHasher(sha3.NewLegacyKeccak512())
+
+			// Calculate the data segment this thread should generate
+			batch := uint32((size + hashBytes*uint64(threads) - 1) / (hashBytes * uint64(threads)))
+			first := uint32(id) * batch
+			limit := first + batch
+			if limit > uint32(size/hashBytes) {
+				limit = uint32(size / hashBytes)
+			}
+			// Calculate the dataset segment
+			percent := uint32(size / hashBytes / 100)
+			for index := first; index < limit; index++ {
+				item := generateDatasetItem(cache, index, keccak512)
+				if swapped {
+					swap(item)
+				}
+				copy(dataset[index*hashBytes:], item)
+
+				if status := atomic.AddUint32(&progress, 1); status%percent == 0 {
+					logger.Info("Generating DAG in progress", "percentage", uint64(status*100)/(size/hashBytes), "elapsed", common.PrettyDuration(time.Since(start)))
+				}
+			}
+		}(i)
+	}
+	// Wait for all the generators to finish and return
+	pend.Wait()
+}
+
+// hashimoto aggregates data from the full dataset in order to produce our final
+// value for a particular header hash and nonce.
+func hashimoto(hash []byte, nonce uint64, size uint64, lookup func(index uint32) []uint32) ([]byte, []byte) {
+	// Calculate the number of theoretical rows (we use one buffer nonetheless)
+	rows := uint32(size / mixBytes)
+
+	// Combine header+nonce into a 64 byte seed
+	seed := make([]byte, 40)
+	copy(seed, hash)
+	binary.LittleEndian.PutUint64(seed[32:], nonce)
+
+	seed = crypto.Keccak512(seed)
+	seedHead := binary.LittleEndian.Uint32(seed)
+
+	// Start the mix with replicated seed
+	mix := make([]uint32, mixBytes/4)
+	for i := 0; i < len(mix); i++ {
+		mix[i] = binary.LittleEndian.Uint32(seed[i%16*4:])
+	}
+	// Mix in random dataset nodes
+	temp := make([]uint32, len(mix))
+
+	for i := 0; i < loopAccesses; i++ {
+		parent := fnv(uint32(i)^seedHead, mix[i%len(mix)]) % rows
+		for j := uint32(0); j < mixBytes/hashBytes; j++ {
+			copy(temp[j*hashWords:], lookup(2*parent+j))
+		}
+		fnvHash(mix, temp)
+	}
+	// Compress mix
+	for i := 0; i < len(mix); i += 4 {
+		mix[i/4] = fnv(fnv(fnv(mix[i], mix[i+1]), mix[i+2]), mix[i+3])
+	}
+	mix = mix[:len(mix)/4]
+
+	digest := make([]byte, common.HashLength)
+	for i, val := range mix {
+		binary.LittleEndian.PutUint32(digest[i*4:], val)
+	}
+	return digest, crypto.Keccak256(append(seed, digest...))
+}
+
+// hashimotoLight aggregates data from the full dataset (using only a small
+// in-memory cache) in order to produce our final value for a particular header
+// hash and nonce.
+func hashimotoLight(size uint64, cache []uint32, hash []byte, nonce uint64) ([]byte, []byte) {
+	keccak512 := makeHasher(sha3.NewLegacyKeccak512())
+
+	lookup := func(index uint32) []uint32 {
+		rawData := generateDatasetItem(cache, index, keccak512)
+
+		data := make([]uint32, len(rawData)/4)
+		for i := 0; i < len(data); i++ {
+			data[i] = binary.LittleEndian.Uint32(rawData[i*4:])
+		}
+		return data
+	}
+	return hashimoto(hash, nonce, size, lookup)
+}
+
+// hashimotoFull aggregates data from the full dataset (using the full in-memory
+// dataset) in order to produce our final value for a particular header hash and
+// nonce.
+func hashimotoFull(dataset []uint32, hash []byte, nonce uint64) ([]byte, []byte) {
+	lookup := func(index uint32) []uint32 {
+		offset := index * hashWords
+		return dataset[offset : offset+hashWords]
+	}
+	return hashimoto(hash, nonce, uint64(len(dataset))*4, lookup)
+}
+
+func colossusEffectiveDatasetBytes(size uint64) uint64 {
+	return (size / colossusPageBytes) * colossusPageBytes
+}
+
+func colossusNumPages(size uint64) uint32 {
+	return uint32(colossusEffectiveDatasetBytes(size) / colossusPageBytes)
+}
+
+func colossusNonceLE(n uint64) [8]byte {
+	var out [8]byte
+	binary.LittleEndian.PutUint64(out[:], n)
+	return out
+}
+
+func colossusRotl32(v, bits uint32) uint32 {
+	return (v << (bits & 31)) | (v >> ((32 - bits) & 31))
+}
+
+func colossusSeedWords(seed []byte) [colossusStateWords]uint32 {
+	var out [colossusStateWords]uint32
+	for i := 0; i < colossusStateWords; i++ {
+		out[i] = binary.LittleEndian.Uint32(seed[i*4:])
+	}
+	return out
+}
+
+func colossusStateBytes(state *[colossusStateWords]uint32, acc *[colossusAccWords]uint32) []byte {
+	out := make([]byte, (colossusStateWords+colossusAccWords)*4)
+	for i := 0; i < colossusStateWords; i++ {
+		binary.LittleEndian.PutUint32(out[i*4:], state[i])
+	}
+	base := colossusStateWords * 4
+	for i := 0; i < colossusAccWords; i++ {
+		binary.LittleEndian.PutUint32(out[base+i*4:], acc[i])
+	}
+	return out
+}
+
+func colossusLookupPageFull(dataset []uint32, pageIndex uint32, out *[colossusPageWords]uint32) {
+	start := int(pageIndex) * colossusPageWords
+	copy(out[:], dataset[start:start+colossusPageWords])
+}
+
+func colossusLookupPageLight(cache []uint32, pageIndex uint32, keccak512 hasher, out *[colossusPageWords]uint32) {
+	baseItem := pageIndex * (colossusPageBytes / hashBytes)
+	for i := uint32(0); i < (colossusPageBytes / hashBytes); i++ {
+		item := generateDatasetItem(cache, baseItem+i, keccak512)
+		wordOffset := int(i) * hashWords
+		for w := 0; w < hashWords; w++ {
+			out[wordOffset+w] = binary.LittleEndian.Uint32(item[w*4:])
+		}
+	}
+}
+
+func colossusHashCoreWithScratchpad(scratchpad []uint32, numPages uint32, sealHash []byte, nonce uint64, pageLookup func(pageIndex uint32, out *[colossusPageWords]uint32)) ([]byte, []byte) {
+	nonceLE := colossusNonceLE(nonce)
+	seed := crypto.Keccak512([]byte(colossusDomainTag), sealHash, nonceLE[:])
+
+	state := colossusSeedWords(seed)
+	var acc [colossusAccWords]uint32
+	for i := 0; i < colossusAccWords; i++ {
+		acc[i] = state[i] ^ state[i+colossusAccWords]
+	}
+
+	scratchpad = scratchpad[:colossusScratchpadWords]
+	for k := uint32(0); k < colossusScratchpadWords; k++ {
+		idx := k % colossusStateWords
+		x := state[idx]
+		y := k
+		z := fnv(x^y, 0x9e3779b9+y)
+		state[idx] = colossusRotl32(x+z, z%32) ^ y
+		scratchpad[k] = state[idx] ^ fnv(z, x+y)
+	}
+
+	var page [colossusPageWords]uint32
+	var tile [colossusTileWords]uint32
+	for r := uint32(0); r < colossusRounds; r++ {
+		a := state[r%colossusStateWords]
+		b := state[(r+5)%colossusStateWords]
+		c := acc[r%colossusAccWords]
+
+		dp := uint32(0)
+		if numPages > 0 {
+			dp = fnv(a^r, b+c) % numPages
+			pageLookup(dp, &page)
+		} else {
+			for i := range page {
+				page[i] = 0
+			}
+		}
+		sp := fnv(b^r, a+c) % colossusNumTiles
+		copy(tile[:], scratchpad[int(sp)*colossusTileWords:int(sp+1)*colossusTileWords])
+
+		for p := uint32(0); p < colossusInternalPasses; p++ {
+			for i := uint32(0); i < colossusTileWords; i++ {
+				x := tile[i]
+				y := page[(i+p*13)%colossusPageWords]
+				sidx := (i + r + p) % colossusStateWords
+				aidx := (i + p) % colossusAccWords
+				z := state[sidx]
+				w := acc[aidx]
+
+				m1 := fnv(x^z, y+r)
+				m2 := colossusRotl32(x+y+w+p, (z^y)%32)
+				m3 := (z * 0x9e3779b1) + (w ^ i)
+				newX := m1 ^ m2 ^ m3
+
+				tile[i] = newX
+				state[sidx] = fnv(z^y, newX+i)
+				acc[aidx] = fnv(w^newX, y+r+p)
+			}
+		}
+
+		state[r%colossusStateWords] ^= tile[(r*7)%colossusTileWords]
+		state[(r+3)%colossusStateWords] = fnv(state[(r+3)%colossusStateWords], tile[(r*11+5)%colossusTileWords])
+		acc[r%colossusAccWords] ^= tile[(r*13+9)%colossusTileWords]
+
+		copy(scratchpad[int(sp)*colossusTileWords:int(sp+1)*colossusTileWords], tile[:])
+	}
+
+	finalState := colossusStateBytes(&state, &acc)
+	mixDigest := crypto.Keccak256(finalState)
+	result := crypto.Keccak256(seed, mixDigest)
+	return mixDigest, result
+}
+
+func colossusHashLightWithScratchpad(scratchpad []uint32, size uint64, cache []uint32, sealHash []byte, nonce uint64) ([]byte, []byte) {
+	numPages := colossusNumPages(size)
+	keccak512 := makeHasher(sha3.NewLegacyKeccak512())
+	return colossusHashCoreWithScratchpad(scratchpad, numPages, sealHash, nonce, func(pageIndex uint32, out *[colossusPageWords]uint32) {
+		colossusLookupPageLight(cache, pageIndex, keccak512, out)
+	})
+}
+
+func colossusHashLight(size uint64, cache []uint32, sealHash []byte, nonce uint64) ([]byte, []byte) {
+	scratchpad := colossusAcquireScratchpad()
+	defer colossusReleaseScratchpad(scratchpad)
+
+	return colossusHashLightWithScratchpad(scratchpad, size, cache, sealHash, nonce)
+}
+
+func colossusHashFullWithScratchpad(scratchpad []uint32, dataset []uint32, sealHash []byte, nonce uint64) ([]byte, []byte) {
+	datasetWords := len(dataset) - (len(dataset) % colossusPageWords)
+	numPages := uint32(datasetWords / colossusPageWords)
+	return colossusHashCoreWithScratchpad(scratchpad, numPages, sealHash, nonce, func(pageIndex uint32, out *[colossusPageWords]uint32) {
+		colossusLookupPageFull(dataset[:datasetWords], pageIndex, out)
+	})
+}
+
+func colossusHashFull(dataset []uint32, sealHash []byte, nonce uint64) ([]byte, []byte) {
+	scratchpad := colossusAcquireScratchpad()
+	defer colossusReleaseScratchpad(scratchpad)
+
+	return colossusHashFullWithScratchpad(scratchpad, dataset, sealHash, nonce)
+}
+
+// maxEpoch bounds the pre-generated future cache/dataset epoch in the LRU.
+const maxEpoch = 2048

--- a/consensus/colossusx/colossus_test.go
+++ b/consensus/colossusx/colossus_test.go
@@ -1,0 +1,91 @@
+package ethash
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func makeLightAndFullInputs(t *testing.T, datasetBytes uint64, epoch uint64) ([]uint32, []uint32) {
+	t.Helper()
+	seed := seedHash(epoch*epochLength + 1)
+	cache := make([]uint32, cacheSize(epoch*epochLength+1)/4)
+	generateCache(cache, epoch, seed)
+	dataset := make([]uint32, datasetBytes/4)
+	generateDataset(dataset, epoch, cache)
+	return cache, dataset
+}
+
+func TestColossusHashLightFullMatch(t *testing.T) {
+	cache, dataset := makeLightAndFullInputs(t, 32*1024, 0)
+	sealHash := make([]byte, 32)
+	for _, nonce := range []uint64{0, 1, 7, 42, 999} {
+		lightDigest, lightResult := colossusHashLight(32*1024, cache, sealHash, nonce)
+		fullDigest, fullResult := colossusHashFull(dataset, sealHash, nonce)
+		if hex.EncodeToString(lightDigest) != hex.EncodeToString(fullDigest) {
+			t.Fatalf("digest mismatch for nonce %d", nonce)
+		}
+		if hex.EncodeToString(lightResult) != hex.EncodeToString(fullResult) {
+			t.Fatalf("result mismatch for nonce %d", nonce)
+		}
+	}
+}
+
+func TestColossusTailTruncationAndPageBoundary(t *testing.T) {
+	cache, dataset := makeLightAndFullInputs(t, 32*1024, 0)
+	sealHash := []byte("0123456789abcdef0123456789abcdef")
+	nonce := uint64(123)
+
+	baseDigest, baseResult := colossusHashFull(dataset, sealHash, nonce)
+	withTailDigest, withTailResult := colossusHashFull(append(append([]uint32{}, dataset...), 1, 2, 3), sealHash, nonce)
+	if hex.EncodeToString(baseDigest) != hex.EncodeToString(withTailDigest) || hex.EncodeToString(baseResult) != hex.EncodeToString(withTailResult) {
+		t.Fatalf("full hash should ignore tail words beyond effective dataset page boundary")
+	}
+
+	lightA1, lightB1 := colossusHashLight(32*1024, cache, sealHash, nonce)
+	lightA2, lightB2 := colossusHashLight(32*1024+17, cache, sealHash, nonce)
+	if hex.EncodeToString(lightA1) != hex.EncodeToString(lightA2) || hex.EncodeToString(lightB1) != hex.EncodeToString(lightB2) {
+		t.Fatalf("light hash should ignore tail bytes beyond effective dataset bytes")
+	}
+}
+
+func TestColossusGoldenVectors(t *testing.T) {
+	cache0, dataset0 := makeLightAndFullInputs(t, 32*1024, 0)
+	cache1, dataset1 := makeLightAndFullInputs(t, 32*1024, 1)
+
+	// Provenance: vectors are derived from the ColossusHash-v1.1 spec formulas
+	// in this package and frozen from a standalone reproduction script.
+	// Regenerate with:
+	//   GO111MODULE=off go run ./tmp_vec_main.go
+	vectors := []struct {
+		name       string
+		dataset    []uint32
+		cache      []uint32
+		datasetLen uint64
+		sealHash   string
+		nonce      uint64
+		digestHex  string
+		resultHex  string
+	}{
+		{name: "epoch0_nonce0", dataset: dataset0, cache: cache0, datasetLen: 32 * 1024, sealHash: "0000000000000000000000000000000000000000000000000000000000000000", nonce: 0, digestHex: "563c594018ce5bbed726d57e3cd319db39c5eebfefc467866b499adc8a77f50f", resultHex: "b06d89147224eb6c91d4639e65bed48c10c72b5cff54011c120303ef22ac96a3"},
+		{name: "epoch0_nonce7", dataset: dataset0, cache: cache0, datasetLen: 32*1024 + 77, sealHash: "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", nonce: 7, digestHex: "2fa020e77a6110794035cb4b784c3347163dfe75a12ac5930c107dd8f7acbaf5", resultHex: "50f2b9dd66dc31c24dfc178dbe6037c5817f196339b27118237bc4775c08fc3f"},
+		{name: "epoch1_nonce42", dataset: dataset1, cache: cache1, datasetLen: 32 * 1024, sealHash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", nonce: 42, digestHex: "a787b9ec9454d87d4a6e3d293e0df787ab13351c67a3e8002f8dab527c7eba3a", resultHex: "91945711a8c64c05a41a76871929e15326ce279628ca27e1825c99749b715ab4"},
+	}
+
+	for _, tc := range vectors {
+		sealHash, err := hex.DecodeString(tc.sealHash)
+		if err != nil {
+			t.Fatalf("decode seal hash: %v", err)
+		}
+		lightDigest, lightResult := colossusHashLight(tc.datasetLen, tc.cache, sealHash, tc.nonce)
+		fullDigest, fullResult := colossusHashFull(tc.dataset, sealHash, tc.nonce)
+		if hex.EncodeToString(lightDigest) != hex.EncodeToString(fullDigest) || hex.EncodeToString(lightResult) != hex.EncodeToString(fullResult) {
+			t.Fatalf("full/light mismatch for %s", tc.name)
+		}
+		if got := hex.EncodeToString(fullDigest); got != tc.digestHex {
+			t.Fatalf("digest mismatch for %s: got %s", tc.name, got)
+		}
+		if got := hex.EncodeToString(fullResult); got != tc.resultHex {
+			t.Fatalf("result mismatch for %s: got %s", tc.name, got)
+		}
+	}
+}

--- a/consensus/colossusx/consensus.go
+++ b/consensus/colossusx/consensus.go
@@ -1,0 +1,709 @@
+// Copyright 2015 The go-ethereum Authors
+// Copyright 2017 The cypherBFT Authors
+// This file is part of the cypherBFT library.
+//
+// The cypherBFT library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The cypherBFT library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the cypherBFT library. If not, see <http://www.gnu.org/licenses/>.
+
+package ethash
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/big"
+	"runtime"
+	"time"
+
+	"github.com/cypherium/cypher/common/math"
+
+	"github.com/cypherium/cypher/common"
+	"github.com/cypherium/cypher/consensus"
+	"github.com/cypherium/cypher/core/state"
+	"github.com/cypherium/cypher/core/types"
+	"github.com/cypherium/cypher/core/vm"
+	"github.com/cypherium/cypher/crypto"
+	"github.com/cypherium/cypher/log"
+	"github.com/cypherium/cypher/params"
+	"github.com/cypherium/cypher/reconfig/bftview"
+	"github.com/cypherium/cypher/trie"
+	//set "gopkg.in/fatih/set.v0"
+)
+
+// Various error messages to mark blocks invalid. These should be private to
+// prevent engine specific errors from being referenced in the remainder of the
+// codebase, inherently breaking if the engine is swapped out. Please put common
+// error types into the pow package.
+var (
+	FrontierBlockReward  = big.NewInt(5e+18) // Block reward in wei for successfully mining a block
+	ByzantiumBlockReward = big.NewInt(3e+18) // Block reward in wei for successfully mining a block upward from Byzantium
+
+	errLargeBlockTime    = errors.New("timestamp too big")
+	errZeroBlockTime     = errors.New("timestamp equals parent's")
+	errTooManyUncles     = errors.New("too many uncles")
+	errDuplicateUncle    = errors.New("duplicate uncle")
+	errUncleIsAncestor   = errors.New("uncle is ancestor")
+	errDanglingUncle     = errors.New("uncle's parent is not ancestor")
+	errInvalidDifficulty = errors.New("non-positive difficulty")
+	errInvalidMixDigest  = errors.New("invalid mix digest")
+	errInvalidPoW        = errors.New("invalid proof-of-work")
+
+	errOlderBlockTime      = errors.New("timestamp older than parent")
+	allowedFutureBlockTime = 5 * time.Minute // Max time from current time allowed for blocks, before they're considered future blocks
+)
+
+// CalcKeyBlockDifficulty is the difficulty adjustment algorithm. It returns
+// the difficulty that a new block should have when created at time
+// given the parent block's time and difficulty.
+func (ethash *Ethash) CalcKeyBlockDifficulty(chain types.KeyChainReader, time uint64, parent *types.KeyBlockHeader) *big.Int {
+	return calcKeyBlockDifficultyByzantium(time, parent)
+}
+
+const (
+	MinFoundedSeconds = 5
+)
+
+// Some weird constants to avoid constant memory allocs for them.
+var (
+	expDiffPeriod = big.NewInt(1000)
+	big1          = big.NewInt(1)
+	big2          = big.NewInt(2)
+	big8          = big.NewInt(8)
+	big9          = big.NewInt(9)
+	big10         = big.NewInt(10)
+	big32         = big.NewInt(32)
+	bigMinus99    = big.NewInt(-99)
+
+	big2999999 = big.NewInt(2999999)
+)
+
+func calcKeyBlockDifficultyByzantium(time uint64, parent *types.KeyBlockHeader) *big.Int {
+	// https://github.com/cypherium/EIPs/issues/100.
+	// algorithm:
+	// diff = (parent_diff +
+	//         (parent_diff / 2048 * max((2 if len(parent.uncles) else 1) - ((timestamp - parent.timestamp) // 9), -99))
+	//        ) + 2^(periodCount - 2)
+
+	bigTime := new(big.Int).SetUint64(time)
+	bigParentTime := new(big.Int).SetUint64(parent.Time)
+
+	// holds intermediate values to make the algo easier to read & audit
+	x := new(big.Int)
+	y := new(big.Int)
+
+	// (2 if len(parent_uncles) else 1) - (block_timestamp - parent_timestamp) // 9
+	x.Sub(bigTime, bigParentTime)
+	x.Div(x, big9)
+	x.Sub(big1, x)
+
+	// max((2 if len(parent_uncles) else 1) - (block_timestamp - parent_timestamp) // 9, -99)
+	if x.Cmp(bigMinus99) < 0 {
+		x.Set(bigMinus99)
+	}
+	// parent_diff + (parent_diff / 2048 * max((2 if len(parent.uncles) else 1) - ((timestamp - parent.timestamp) // 9), -99))
+	y.Div(parent.Difficulty, params.DifficultyBoundDivisor)
+	x.Mul(y, x)
+	x.Add(parent.Difficulty, x)
+
+	// minimum difficulty can ever be (before exponential factor)
+	if x.Cmp(params.MinimumDifficulty) < 0 {
+		x.Set(params.MinimumDifficulty)
+	}
+	// calculate a fake block number for the ice-age delay:
+	//   https://github.com/cypherium/EIPs/pull/669
+	//   fake_block_number = min(0, block.number - 3_000_000
+	fakeBlockNumber := new(big.Int)
+	if parent.Number.Cmp(big2999999) >= 0 {
+		fakeBlockNumber = fakeBlockNumber.Sub(parent.Number, big2999999) // Note, parent is 1 less than the actual block number
+	}
+	// for the exponential factor
+	periodCount := fakeBlockNumber
+	periodCount.Div(periodCount, expDiffPeriod)
+
+	// the exponential factor, commonly referred to as "the bomb"
+	// diff = diff + 2^(periodCount - 2)
+	if periodCount.Cmp(big1) > 0 {
+		y.Sub(periodCount, big2)
+		y.Exp(big2, y, nil)
+		x.Add(x, y)
+	}
+	return x
+}
+
+// //////////////////////////////////////////////////////////////////////////////////////////////
+// VerifyCandidate implements pow.Engine, checking whether the given candidate satisfies
+// the PoW difficulty requirements.
+func (ethash *Ethash) VerifyCandidate(chain types.KeyChainReader, candidate *types.Candidate) error {
+	// If we're running a fake PoW, accept any seal as valid
+	if ethash.config.PowMode == ModeFake || ethash.config.PowMode == ModeFullFake {
+		// time.Sleep(ethash.fakeDelay)
+		if ethash.fakeFail == candidate.KeyCandidate.Number.Uint64() {
+			return errInvalidPoW
+		}
+		return nil
+	}
+
+	// If we're running a shared PoW, delegate verification to it
+	if ethash.shared != nil {
+		return ethash.shared.VerifyCandidate(chain, candidate)
+	}
+	return ethash.VerifyKeyHeaderSeal(candidate.KeyCandidate)
+}
+
+// VerifyKeyHeaderSeal checks whether the given key block header satisfies
+// the key-block Colossus PoW requirements.
+func (ethash *Ethash) VerifyKeyHeaderSeal(header *types.KeyBlockHeader) error {
+	// If we're running a fake PoW, accept any seal as valid.
+	if ethash.config.PowMode == ModeFake || ethash.config.PowMode == ModeFullFake {
+		if ethash.fakeFail == header.Number.Uint64() {
+			return errInvalidPoW
+		}
+		return nil
+	}
+	// If we're running a shared PoW, delegation must be supported too.
+	// Otherwise candidate verification and key-header verification can diverge.
+	if ethash.shared != nil {
+		if s, ok := interface{}(ethash.shared).(interface {
+			VerifyKeyHeaderSeal(*types.KeyBlockHeader) error
+		}); ok {
+			return s.VerifyKeyHeaderSeal(header)
+		}
+		return fmt.Errorf("shared consensus engine does not support key header seal verification")
+	}
+	if header.Difficulty == nil || header.Difficulty.Sign() <= 0 {
+		return errInvalidDifficulty
+	}
+	// Recompute the digest and PoW value and verify against the header.
+	number := header.Number.Uint64()
+
+	cache := ethash.cache(number)
+	size := datasetSize(number)
+	if ethash.config.PowMode == ModeTest {
+		size = 32 * 1024
+	}
+	digest, result := colossusHashLight(size, cache.cache, header.SealHash().Bytes(), header.Nonce.Uint64())
+	// Caches are unmapped in a finalizer. Ensure that the cache stays live
+	// until after the call to colossusHashLight so it's not unmapped while being used.
+	runtime.KeepAlive(cache)
+
+	if !bytes.Equal(header.MixDigest[:], digest) {
+		return errInvalidMixDigest
+	}
+
+	target := new(big.Int).Div(maxUint256, header.Difficulty)
+	if new(big.Int).SetBytes(result).Cmp(target) > 0 {
+		return errInvalidPoW
+	}
+	return nil
+}
+
+// VerifyHeaderSeal checks whether the given normal block header satisfies
+// ethash/colossus PoW requirements.
+func (ethash *Ethash) VerifyHeaderSeal(header *types.Header) error {
+	// If we're running a fake PoW, accept any seal as valid
+	if ethash.config.PowMode == ModeFake || ethash.config.PowMode == ModeFullFake {
+		if ethash.fakeFail == header.Number.Uint64() {
+			return errInvalidPoW
+		}
+		return nil
+	}
+	// If we're running a shared PoW, delegate verification to it.
+	if ethash.shared != nil {
+		return ethash.shared.VerifyHeaderSeal(header)
+	}
+	if header.Difficulty == nil || header.Difficulty.Sign() <= 0 {
+		return errInvalidDifficulty
+	}
+	number := header.Number.Uint64()
+	cache := ethash.cache(number)
+	size := datasetSize(number)
+	if ethash.config.PowMode == ModeTest {
+		size = 32 * 1024
+	}
+	digest, result := colossusHashLight(size, cache.cache, header.SealHash().Bytes(), header.Nonce.Uint64())
+	runtime.KeepAlive(cache)
+
+	if !bytes.Equal(header.MixDigest[:], digest) {
+		return errInvalidMixDigest
+	}
+	target := new(big.Int).Div(maxUint256, header.Difficulty)
+	if new(big.Int).SetBytes(result).Cmp(target) > 0 {
+		return errInvalidPoW
+	}
+	return nil
+}
+
+// SealHeader searches a PoW nonce for a normal block header and fills
+// header.Nonce/header.MixDigest in-place.
+func (ethash *Ethash) SealHeader(header *types.Header, stop <-chan struct{}) error {
+	if header.Difficulty == nil || header.Difficulty.Sign() <= 0 {
+		return errInvalidDifficulty
+	}
+	// Fake modes don't need real mining work.
+	if ethash.config.PowMode == ModeFake || ethash.config.PowMode == ModeFullFake {
+		header.Nonce = types.EncodeNonce(1)
+		header.MixDigest = common.BytesToHash(crypto.Keccak256(header.SealHash().Bytes()))
+		return nil
+	}
+	if ethash.shared != nil {
+		return ethash.shared.SealHeader(header, stop)
+	}
+
+	number := header.Number.Uint64()
+	target := new(big.Int).Div(maxUint256, header.Difficulty)
+	hash := header.SealHash().Bytes()
+	dataset := ethash.dataset(number)
+	defer runtime.KeepAlive(dataset)
+	scratchpad := colossusAcquireScratchpad()
+	defer colossusReleaseScratchpad(scratchpad)
+
+	for nonce := uint64(0); ; nonce++ {
+		select {
+		case <-stop:
+			return errors.New("sealing aborted")
+		default:
+		}
+		digest, result := colossusHashFullWithScratchpad(scratchpad, dataset.dataset, hash, nonce)
+		if new(big.Int).SetBytes(result).Cmp(target) <= 0 {
+			header.Nonce = types.EncodeNonce(nonce)
+			header.MixDigest = common.BytesToHash(digest)
+			return nil
+		}
+	}
+}
+
+// Prepare implements pow.Engine, initializing the difficulty field of a
+// candidate to conform to the ethash protocol. The changes are done inline.
+func (ethash *Ethash) PrepareCandidate(chain types.KeyChainReader, candidate *types.Candidate, committeeSize int) error {
+	log.Debug("prepare candidate from header", "hash", candidate.KeyCandidate.ParentHash, "number", candidate.KeyCandidate.Number.Uint64()-1)
+
+	parent := chain.GetHeader(candidate.KeyCandidate.ParentHash, candidate.KeyCandidate.Number.Uint64()-1)
+	if parent == nil {
+		return consensus.ErrUnknownAncestor
+	}
+
+	candidate.KeyCandidate.Difficulty = calcCandidateDifficulty(candidate.KeyCandidate.Time, parent, committeeSize)
+	log.Info("PrepareCandidate", "parent difficulty", parent.Difficulty, "current difficulty", candidate.KeyCandidate.Difficulty, "minus value", candidate.KeyCandidate.Difficulty.Int64()-parent.Difficulty.Int64(), "committeeSize", committeeSize)
+	return nil
+}
+
+// calcCandidateDifficulty is the difficulty adjustment algorithm. It returns
+// the difficulty that a new candidate should have when created at time
+// given the keyblock's time and difficulty.
+func calcCandidateDifficulty(time uint64, parent *types.KeyBlockHeader, committeeSize int) *big.Int {
+	// algorithm:
+	// diff = (parent_diff +
+	//         (parent_diff / 2048 * max(1 - (block_timestamp - parent_timestamp) // 10, -99))
+	//        ) + 2^(periodCount - 2)
+
+	bigTime := new(big.Int).SetUint64(time)
+	bigParentTime := new(big.Int).SetUint64(parent.Time)
+
+	// holds intermediate values to make the algo easier to read & audit
+	x := new(big.Int)
+	y := new(big.Int)
+
+	// 1 - (block_timestamp - parent_timestamp) // 10
+	x.Sub(bigTime, bigParentTime)
+	x.Div(x, big.NewInt(50))
+	x.Sub(big1, x)
+
+	// max(1 - (block_timestamp - parent_timestamp) // 10, -99)
+	if x.Cmp(bigMinus99) < 0 {
+		x.Set(bigMinus99)
+	}
+	// (parent_diff + (parent_diff // 2048) * max(1 - (block_timestamp - parent_timestamp) // 10, -99))
+	y.Div(parent.Difficulty, params.DifficultyBoundDivisor)
+	x.Mul(y, x)
+	x.Add(parent.Difficulty, x)
+
+	// minimum difficulty can ever be (before exponential factor)
+	if x.Cmp(params.MinimumDifficulty) < 0 {
+		x.Set(params.MinimumDifficulty)
+	}
+	// for the exponential factor
+	periodCount := big.NewInt(int64(committeeSize))
+	periodCount.Div(periodCount, expDiffPeriod)
+
+	// the exponential factor, commonly referred to as "the bomb"
+	// diff = diff + 2^(periodCount - 2)
+	if periodCount.Cmp(big1) > 0 {
+		y.Sub(periodCount, big2)
+		y.Exp(big2, y, nil)
+		x.Add(x, y)
+	}
+	return x
+}
+
+func (ethash *Ethash) PowMode() uint {
+	return uint(ethash.config.PowMode)
+}
+
+// ----------------------------------------------------------------------------------------
+// Author implements consensus.Engine, returning the header's coinbase as the
+// proof-of-work verified author of the block.
+func (ethash *Ethash) Author(header *types.Header) (common.Address, error) {
+	return header.Coinbase, nil
+}
+func (ethash *Ethash) Author0(header *types.Header) (common.PublicKey25519, error) {
+	return common.PublicKey25519{}, nil
+}
+
+// VerifyHeader checks whether a header conforms to the consensus rules of the
+// stock Ethereum ethash engine.
+func (ethash *Ethash) VerifyHeader(chain consensus.ChainHeaderReader, header *types.Header, seal bool) error {
+	// If we're running a full engine faking, accept any input as valid
+	if ethash.config.PowMode == ModeFullFake {
+		return nil
+	}
+	// Short circuit if the header is known, or its parent not
+	number := header.Number.Uint64()
+	if chain.GetHeader(header.Hash(), number) != nil {
+		return nil
+	}
+	parent := chain.GetHeader(header.ParentHash, number-1)
+	if parent == nil {
+		return consensus.ErrUnknownAncestor
+	}
+	// Sanity checks passed, do a proper verification
+	return ethash.verifyHeader(chain, header, parent, false, seal)
+}
+
+// VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers
+// concurrently. The method returns a quit channel to abort the operations and
+// a results channel to retrieve the async verifications.
+func (ethash *Ethash) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+	// If we're running a full engine faking, accept any input as valid
+	if ethash.config.PowMode == ModeFullFake || len(headers) == 0 {
+		abort, results := make(chan struct{}), make(chan error, len(headers))
+		for i := 0; i < len(headers); i++ {
+			results <- nil
+		}
+		return abort, results
+	}
+
+	// Spawn as many workers as allowed threads
+	workers := runtime.GOMAXPROCS(0)
+	if len(headers) < workers {
+		workers = len(headers)
+	}
+
+	// Create a task channel and spawn the verifiers
+	var (
+		inputs = make(chan int)
+		done   = make(chan int, workers)
+		errors = make([]error, len(headers))
+		abort  = make(chan struct{})
+	)
+	for i := 0; i < workers; i++ {
+		go func() {
+			for index := range inputs {
+				errors[index] = ethash.verifyHeaderWorker(chain, headers, seals, index)
+				done <- index
+			}
+		}()
+	}
+
+	errorsOut := make(chan error, len(headers))
+	go func() {
+		defer close(inputs)
+		var (
+			in, out = 0, 0
+			checked = make([]bool, len(headers))
+			inputs  = inputs
+		)
+		for {
+			select {
+			case inputs <- in:
+				if in++; in == len(headers) {
+					// Reached end of headers. Stop sending to workers.
+					inputs = nil
+				}
+			case index := <-done:
+				for checked[index] = true; checked[out]; out++ {
+					errorsOut <- errors[out]
+					if out == len(headers)-1 {
+						return
+					}
+				}
+			case <-abort:
+				return
+			}
+		}
+	}()
+	return abort, errorsOut
+}
+
+func (ethash *Ethash) verifyHeaderWorker(chain consensus.ChainHeaderReader, headers []*types.Header, seals []bool, index int) error {
+	var parent *types.Header
+	if index == 0 {
+		parent = chain.GetHeader(headers[0].ParentHash, headers[0].Number.Uint64()-1)
+	} else if headers[index-1].Hash() == headers[index].ParentHash {
+		parent = headers[index-1]
+	}
+	if parent == nil {
+		return consensus.ErrUnknownAncestor
+	}
+	if chain.GetHeader(headers[index].Hash(), headers[index].Number.Uint64()) != nil {
+		return nil // known block
+	}
+	return ethash.verifyHeader(chain, headers[index], parent, false, seals[index])
+}
+
+// verifyHeader checks whether a header conforms to the consensus rules of the
+// stock Ethereum ethash engine.
+// See YP section 4.3.4. "Block Header Validity"
+func (ethash *Ethash) verifyHeader(chain consensus.ChainHeaderReader, header, parent *types.Header, uncle bool, seal bool) error {
+	// Ensure that the header's extra-data section is of a reasonable size
+	if uint64(len(header.Extra)) > params.MaximumExtraDataSize {
+		return fmt.Errorf("extra-data too long: %d > %d", len(header.Extra), params.MaximumExtraDataSize)
+	}
+	// Verify the header's timestamp
+	if !uncle {
+		if header.Time > uint64(time.Now().Add(allowedFutureBlockTime).Unix()) {
+			return consensus.ErrFutureBlock
+		}
+	}
+	if header.Time <= parent.Time {
+		return errOlderBlockTime
+	}
+
+	// Verify the block's difficulty based on its timestamp and parent's difficulty
+	if header.Difficulty == nil || header.Difficulty.Sign() <= 0 {
+		return errInvalidDifficulty
+	}
+	expected := ethash.CalcDifficulty(chain, header.Time, parent)
+	if expected.Cmp(header.Difficulty) != 0 {
+		return fmt.Errorf("invalid difficulty: have %v, want %v", header.Difficulty, expected)
+	}
+
+	// Verify that the gas limit is <= 2^63-1
+	cap := uint64(0x7fffffffffffffff)
+	if header.GasLimit > cap {
+		return fmt.Errorf("invalid gasLimit: have %v, max %v", header.GasLimit, cap)
+	}
+	// Verify that the gasUsed is <= gasLimit
+	if header.GasUsed > header.GasLimit {
+		return fmt.Errorf("invalid gasUsed: have %d, gasLimit %d", header.GasUsed, header.GasLimit)
+	}
+
+	// Verify that the gas limit remains within allowed bounds
+	diff := int64(parent.GasLimit) - int64(header.GasLimit)
+	if diff < 0 {
+		diff *= -1
+	}
+	limit := parent.GasLimit / params.OriginalGasLimitBoundDivisor
+
+	if uint64(diff) >= limit || header.GasLimit < params.OriginalMinGasLimit {
+		return fmt.Errorf("invalid gas limit: have %d, want %d += %d", header.GasLimit, parent.GasLimit, limit)
+	}
+	// Verify that the block number is parent's +1
+	if diff := new(big.Int).Sub(header.Number, parent.Number); diff.Cmp(big.NewInt(1)) != 0 {
+		return consensus.ErrInvalidNumber
+	}
+
+	// Verify the engine specific seal securing the block.
+	// In UMA-PoW normal block headers use the Colossus path.
+	if seal {
+		if err := ethash.VerifyHeaderSeal(header); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Finalize implements consensus.Engine, accumulating the block and uncle rewards,
+// setting the final state on the header
+func (ethash *Ethash) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, totalGas uint64) {
+	// Accumulate any block and uncle rewards and commit the final state root
+	accumulateRewards(chain.Config(), state, header, uncles)
+
+	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
+}
+
+// FinalizeAndAssemble implements consensus.Engine, accumulating the block and
+// uncle rewards, setting the final state and assembling the block.
+func (ethash *Ethash) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
+	// Accumulate any block and uncle rewards and commit the final state root
+	accumulateRewards(chain.Config(), state, header, uncles)
+	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
+
+	// Header seems complete, assemble into a block and return
+	return types.NewBlock(header, txs, uncles, receipts, new(trie.Trie)), nil
+}
+
+// CalcDifficulty is the difficulty adjustment algorithm. It returns
+// the difficulty that a new block should have when created at time
+// given the parent block's time and difficulty.
+func (ethash *Ethash) CalcDifficulty(chain consensus.ChainHeaderReader, time uint64, parent *types.Header) *big.Int {
+	return CalcDifficulty(chain.Config(), time, parent)
+}
+
+// CalcDifficulty is the difficulty adjustment algorithm. It returns
+// the difficulty that a new block should have when created at time
+// given the parent block's time and difficulty.
+func CalcDifficulty(config *params.ChainConfig, time uint64, parent *types.Header) *big.Int {
+	return calcDifficultyFrontier(time, parent)
+}
+
+// calcDifficultyFrontier is the difficulty adjustment algorithm. It returns the
+// difficulty that a new block should have when created at time given the parent
+// block's time and difficulty. The calculation uses the Frontier rules.
+func calcDifficultyFrontier(time uint64, parent *types.Header) *big.Int {
+	diff := new(big.Int)
+	adjust := new(big.Int).Div(parent.Difficulty, params.DifficultyBoundDivisor)
+	bigTime := new(big.Int)
+	bigParentTime := new(big.Int)
+
+	bigTime.SetUint64(time)
+	bigParentTime.SetUint64(parent.Time)
+
+	if bigTime.Sub(bigTime, bigParentTime).Cmp(params.DurationLimit) < 0 {
+		diff.Add(parent.Difficulty, adjust)
+	} else {
+		diff.Sub(parent.Difficulty, adjust)
+	}
+	if diff.Cmp(params.MinimumDifficulty) < 0 {
+		diff.Set(params.MinimumDifficulty)
+	}
+
+	periodCount := new(big.Int).Add(parent.Number, big1)
+	periodCount.Div(periodCount, expDiffPeriod)
+	if periodCount.Cmp(big1) > 0 {
+		// diff = diff + 2^(periodCount - 2)
+		expDiff := periodCount.Sub(periodCount, big2)
+		expDiff.Exp(big2, expDiff, nil)
+		diff.Add(diff, expDiff)
+		diff = math.BigMax(diff, params.MinimumDifficulty)
+	}
+	return diff
+}
+
+// AccumulateRewards credits the coinbase of the given block with the mining
+// reward. The total reward consists of the static block reward and rewards for
+// included uncles. The coinbase of each uncle block is also rewarded.
+func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header *types.Header, uncles []*types.Header) {
+	// Select the correct block reward based on chain progression
+	blockReward := FrontierBlockReward
+	// Accumulate the rewards for the miner and any included uncles
+	reward := new(big.Int).Set(blockReward)
+	r := new(big.Int)
+	for _, uncle := range uncles {
+		r.Add(uncle.Number, big8)
+		r.Sub(r, header.Number)
+		r.Mul(r, blockReward)
+		r.Div(r, big8)
+		state.AddBalance(uncle.Coinbase, r)
+
+		r.Div(blockReward, big32)
+		reward.Add(reward, r)
+	}
+	state.AddBalance(header.Coinbase, reward)
+}
+
+// wrapper for accumulateRewards to be called by raft minter
+func AccumulateRewards(config *params.ChainConfig, state *state.StateDB, header *types.Header, uncles []*types.Header) {
+	accumulateRewards(config, state, header, uncles)
+}
+
+func RewardCommites(bc types.ChainReader, state vm.StateDB, header *types.Header, blockReward uint64, beNewVer bool) {
+	bRewardAll := false
+	//if header.BlockType == types.IsKeyBlockType {
+	//		bRewardAll = true
+	//}
+	//log.Info("RewardCommites", "blockReward", blockReward)
+	if blockReward == 0 {
+		return
+	}
+	pBlock := bc.GetBlock(header.ParentHash, header.Number.Uint64()-1)
+	if pBlock == nil {
+		log.Error("RewardCommites", "not found parent header hash", header.ParentHash)
+		return
+	}
+
+	keyHash := pBlock.KeyHash()
+	if !beNewVer && header.KeyHash != keyHash {
+		kheader := bc.GetKeyChainReader().GetHeaderByHash(header.KeyHash)
+		if kheader.HasNewNode() {
+			kNumber := kheader.NumberU64()
+			cnodes := bc.GetKeyChainReader().GetCommitteeByNumber(kNumber)
+			if cnodes == nil {
+				log.Error("RewardCommites", "not found committee keyNumber", kNumber)
+				return
+			}
+			c := &bftview.Committee{List: cnodes}
+			state.AddBalance(common.HexToAddress(c.In().CoinBase), big.NewInt(params.KeyBlock_Reward))
+		}
+	}
+
+	kheader := bc.GetKeyChainReader().GetHeaderByHash(keyHash)
+	if kheader == nil {
+		log.Error("RewardCommites", "not found key hash", keyHash)
+		return
+	}
+	kNumber := kheader.NumberU64()
+	cnodes := bc.GetKeyChainReader().GetCommitteeByNumber(kNumber)
+	if cnodes == nil {
+		log.Error("RewardCommites", "not found committee keyNumber", kNumber)
+		return
+	}
+	var addresses []common.Address
+	if bRewardAll {
+		for _, r := range cnodes {
+			addresses = append(addresses, common.HexToAddress(r.CoinBase))
+		}
+	} else {
+		/*??
+		mycommittee := &bftview.Committee{List: cnodes}
+		pubs := mycommittee.ToBlsPublicKeys(keyHash)
+		exceptions := hotstuff.MaskToException(pBlock.Exceptions(), pubs, beNewVer)
+		for i, pub := range pubs {
+			isException := false
+			for _, exp := range exceptions {
+				if exp.IsEqual(pub) {
+					isException = true
+					break
+				}
+			}
+
+			if !isException {
+				//address := crypto.PubKeyToAddressCypherium(publicKey)
+				addr := mycommittee.List[i].CoinBase
+				//log.Info("Rewards", "address", addr)
+				//if len(addr) > 16 {
+				addresses = append(addresses, common.HexToAddress(addr))
+				//}
+			}
+		}
+		*/
+	}
+	n := len(addresses)
+	if n < 4 {
+		log.Error("RewardCommites", "committee number", n)
+		return
+	}
+
+	average := blockReward / uint64(n)
+	bigAverage := big.NewInt(int64(average))
+	//log.Info("Rewards", "BlockType", header.BlockType, "total", blockReward, "committeeCount", n, "average", average)
+	for i := 0; i < n; i++ {
+		if i == 0 {
+			left := blockReward - average*uint64(n-1)
+			//log.Info("Rewards", "leader address", addresses[i], "value", left)
+			state.AddBalance(addresses[i], big.NewInt(int64(left)))
+		} else {
+			//log.Info("Rewards", "address", addresses[i], "average", average)
+			state.AddBalance(addresses[i], bigAverage)
+		}
+	}
+}

--- a/consensus/colossusx/ethash.go
+++ b/consensus/colossusx/ethash.go
@@ -1,0 +1,593 @@
+// Copyright 2015 The go-ethereum Authors
+// Copyright 2017 The cypherBFT Authors
+// This file is part of the cypherBFT library.
+//
+// The cypherBFT library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The cypherBFT library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the cypherBFT library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package ethash implements the ethash proof-of-work pow engine.
+
+package ethash
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strconv"
+	"sync"
+	"time"
+	"unsafe"
+
+	mmap "github.com/edsrzf/mmap-go"
+	"github.com/cypherium/cypher/consensus"
+	"github.com/cypherium/cypher/log"
+	"github.com/cypherium/cypher/metrics"
+	"github.com/cypherium/cypher/rpc"
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+var ErrInvalidDumpMagic = errors.New("invalid dump magic")
+
+var (
+	// maxUint256 is a big integer representing 2^256-1
+	maxUint256 = new(big.Int).Exp(big.NewInt(2), big.NewInt(256), big.NewInt(0))
+
+	// sharedCphash is a full instance that can be shared between multiple users.
+	sharedCphash = New(Config{"", 3, 0, "", 1, 0, ModeFullFake, false, false})
+
+	// algorithmRevision is the data structure version used for file naming.
+	algorithmRevision = 24
+
+	// dumpMagic is a dataset dump header to sanity check a data dump.
+	dumpMagic = []uint32{0xbaddcafe, 0xfee1dead}
+)
+
+// isLittleEndian returns whether the local system is running in little or big
+// endian byte order.
+func isLittleEndian() bool {
+	n := uint32(0x01020304)
+	return *(*byte)(unsafe.Pointer(&n)) == 0x04
+}
+
+// memoryMap tries to memory map a file of uint32s for read only access.
+func memoryMap(path string) (*os.File, mmap.MMap, []uint32, error) {
+	file, err := os.OpenFile(path, os.O_RDONLY, 0644)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	mem, buffer, err := memoryMapFile(file, false)
+	if err != nil {
+		file.Close()
+		return nil, nil, nil, err
+	}
+	for i, magic := range dumpMagic {
+		if buffer[i] != magic {
+			mem.Unmap()
+			file.Close()
+			return nil, nil, nil, ErrInvalidDumpMagic
+		}
+	}
+	return file, mem, buffer[len(dumpMagic):], err
+}
+
+// memoryMapFile tries to memory map an already opened file descriptor.
+func memoryMapFile(file *os.File, write bool) (mmap.MMap, []uint32, error) {
+	// Try to memory map the file
+	flag := mmap.RDONLY
+	if write {
+		flag = mmap.RDWR
+	}
+	mem, err := mmap.Map(file, flag, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Yay, we managed to memory map the file, here be dragons
+	header := *(*reflect.SliceHeader)(unsafe.Pointer(&mem))
+	header.Len /= 4
+	header.Cap /= 4
+
+	return mem, *(*[]uint32)(unsafe.Pointer(&header)), nil
+}
+
+// memoryMapAndGenerate tries to memory map a temporary file of uint32s for write
+// access, fill it with the data from a generator and then move it into the final
+// path requested.
+func memoryMapAndGenerate(path string, size uint64, generator func(buffer []uint32)) (*os.File, mmap.MMap, []uint32, error) {
+	// Ensure the data folder exists
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, nil, nil, err
+	}
+	// Create a huge temporary empty file to fill with data
+	temp := path + "." + strconv.Itoa(rand.Int())
+
+	dump, err := os.Create(temp)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if err = dump.Truncate(int64(len(dumpMagic))*4 + int64(size)); err != nil {
+		return nil, nil, nil, err
+	}
+	// Memory map the file for writing and fill it with the generator
+	mem, buffer, err := memoryMapFile(dump, true)
+	if err != nil {
+		dump.Close()
+		return nil, nil, nil, err
+	}
+	copy(buffer, dumpMagic)
+
+	data := buffer[len(dumpMagic):]
+	generator(data)
+
+	if err := mem.Unmap(); err != nil {
+		return nil, nil, nil, err
+	}
+	if err := dump.Close(); err != nil {
+		return nil, nil, nil, err
+	}
+	if err := os.Rename(temp, path); err != nil {
+		return nil, nil, nil, err
+	}
+	return memoryMap(path)
+}
+
+// lru tracks caches or datasets by their last use time, keeping at most N of them.
+type lru struct {
+	what string
+	new  func(epoch uint64) interface{}
+	mu   sync.Mutex
+	// Items are kept in a LRU cache, but there is a special case:
+	// We always keep an item for (highest seen epoch) + 1 as the 'future item'.
+	cache      *simplelru.LRU
+	future     uint64
+	futureItem interface{}
+}
+
+// newlru create a new least-recently-used cache for either the verification caches
+// or the mining datasets.
+func newlru(what string, maxItems int, new func(epoch uint64) interface{}) *lru {
+	if maxItems <= 0 {
+		maxItems = 1
+	}
+	cache, _ := simplelru.NewLRU(maxItems, func(key, value interface{}) {
+		log.Trace("Evicted ethash "+what, "epoch", key)
+	})
+	return &lru{what: what, new: new, cache: cache}
+}
+
+// get retrieves or creates an item for the given epoch. The first return value is always
+// non-nil. The second return value is non-nil if lru thinks that an item will be useful in
+// the near future.
+func (lru *lru) get(epoch uint64) (item, future interface{}) {
+	lru.mu.Lock()
+	defer lru.mu.Unlock()
+
+	// Get or create the item for the requested epoch.
+	item, ok := lru.cache.Get(epoch)
+	if !ok {
+		if lru.future > 0 && lru.future == epoch {
+			item = lru.futureItem
+		} else {
+			log.Trace("Requiring new ethash "+lru.what, "epoch", epoch)
+			item = lru.new(epoch)
+		}
+		lru.cache.Add(epoch, item)
+	}
+	// Update the 'future item' if epoch is larger than previously seen.
+	if epoch < maxEpoch-1 && lru.future < epoch+1 {
+		log.Trace("Requiring new future ethash "+lru.what, "epoch", epoch+1)
+		future = lru.new(epoch + 1)
+		lru.future = epoch + 1
+		lru.futureItem = future
+	}
+	return item, future
+}
+
+// cache wraps an ethash cache with some metadata to allow easier concurrent use.
+type cache struct {
+	epoch uint64    // Epoch for which this cache is relevant
+	dump  *os.File  // File descriptor of the memory mapped cache
+	mmap  mmap.MMap // Memory map itself to unmap before releasing
+	cache []uint32  // The actual cache data content (may be memory mapped)
+	once  sync.Once // Ensures the cache is generated only once
+}
+
+// newCache creates a new ethash verification cache and returns it as a plain Go
+// interface to be usable in an LRU cache.
+func newCache(epoch uint64) interface{} {
+	return &cache{epoch: epoch}
+}
+
+// generate ensures that the cache content is generated before use.
+func (c *cache) generate(dir string, limit int, test bool) {
+	c.once.Do(func() {
+		size := cacheSize(c.epoch*epochLength + 1)
+		seed := seedHash(c.epoch*epochLength + 1)
+		if test {
+			size = 1024
+		}
+		// If we don't store anything on disk, generate and return.
+		if dir == "" {
+			c.cache = make([]uint32, size/4)
+			generateCache(c.cache, c.epoch, seed)
+			return
+		}
+		// Disk storage is needed, this will get fancy
+		var endian string
+		if !isLittleEndian() {
+			endian = ".be"
+		}
+		path := filepath.Join(dir, fmt.Sprintf("cache-R%d-%x%s", algorithmRevision, seed[:8], endian))
+		logger := log.New("epoch", c.epoch)
+
+		// We're about to mmap the file, ensure that the mapping is cleaned up when the
+		// cache becomes unused.
+		runtime.SetFinalizer(c, (*cache).finalizer)
+
+		// Try to load the file from disk and memory map it
+		var err error
+		c.dump, c.mmap, c.cache, err = memoryMap(path)
+		if err == nil {
+			logger.Debug("Loaded old ethash cache from disk")
+			return
+		}
+		logger.Debug("Failed to load old ethash cache", "err", err)
+
+		// No previous cache available, create a new cache file to fill
+		c.dump, c.mmap, c.cache, err = memoryMapAndGenerate(path, size, func(buffer []uint32) { generateCache(buffer, c.epoch, seed) })
+		if err != nil {
+			logger.Error("Failed to generate mapped ethash cache", "err", err)
+
+			c.cache = make([]uint32, size/4)
+			generateCache(c.cache, c.epoch, seed)
+		}
+		// Iterate over all previous instances and delete old ones
+		for ep := int(c.epoch) - limit; ep >= 0; ep-- {
+			seed := seedHash(uint64(ep)*epochLength + 1)
+			path := filepath.Join(dir, fmt.Sprintf("cache-R%d-%x%s", algorithmRevision, seed[:8], endian))
+			os.Remove(path)
+		}
+	})
+}
+
+// finalizer unmaps the memory and closes the file.
+func (c *cache) finalizer() {
+	if c.mmap != nil {
+		c.mmap.Unmap()
+		c.dump.Close()
+		c.mmap, c.dump = nil, nil
+	}
+}
+
+// dataset wraps an ethash dataset with some metadata to allow easier concurrent use.
+type dataset struct {
+	epoch   uint64    // Epoch for which this cache is relevant
+	dump    *os.File  // File descriptor of the memory mapped cache
+	mmap    mmap.MMap // Memory map itself to unmap before releasing
+	dataset []uint32  // The actual cache data content
+	once    sync.Once // Ensures the cache is generated only once
+}
+
+// newDataset creates a new ethash mining dataset and returns it as a plain Go
+// interface to be usable in an LRU cache.
+func newDataset(epoch uint64) interface{} {
+	return &dataset{epoch: epoch}
+}
+
+// generate ensures that the dataset content is generated before use.
+func (d *dataset) generate(dir string, limit int, test bool) {
+	d.once.Do(func() {
+		csize := cacheSize(d.epoch*epochLength + 1)
+		dsize := datasetSize(d.epoch*epochLength + 1)
+		seed := seedHash(d.epoch*epochLength + 1)
+		if test {
+			csize = 1024
+			dsize = 32 * 1024
+		}
+		// If we don't store anything on disk, generate and return
+		if dir == "" {
+			cache := make([]uint32, csize/4)
+			generateCache(cache, d.epoch, seed)
+
+			d.dataset = make([]uint32, dsize/4)
+			generateDataset(d.dataset, d.epoch, cache)
+			return
+		}
+		// Disk storage is needed, this will get fancy
+		var endian string
+		if !isLittleEndian() {
+			endian = ".be"
+		}
+		path := filepath.Join(dir, fmt.Sprintf("full-R%d-%x%s", algorithmRevision, seed[:8], endian))
+		logger := log.New("epoch", d.epoch)
+
+		// We're about to mmap the file, ensure that the mapping is cleaned up when the
+		// cache becomes unused.
+		runtime.SetFinalizer(d, (*dataset).finalizer)
+
+		// Try to load the file from disk and memory map it
+		var err error
+		d.dump, d.mmap, d.dataset, err = memoryMap(path)
+		if err == nil {
+			logger.Debug("Loaded old ethash dataset from disk")
+			return
+		}
+		logger.Debug("Failed to load old ethash dataset", "err", err)
+
+		// No previous dataset available, create a new dataset file to fill
+		cache := make([]uint32, csize/4)
+		generateCache(cache, d.epoch, seed)
+
+		d.dump, d.mmap, d.dataset, err = memoryMapAndGenerate(path, dsize, func(buffer []uint32) { generateDataset(buffer, d.epoch, cache) })
+		if err != nil {
+			logger.Error("Failed to generate mapped ethash dataset", "err", err)
+
+			d.dataset = make([]uint32, dsize/4)
+			generateDataset(d.dataset, d.epoch, cache)
+		}
+		// Iterate over all previous instances and delete old ones
+		for ep := int(d.epoch) - limit; ep >= 0; ep-- {
+			seed := seedHash(uint64(ep)*epochLength + 1)
+			path := filepath.Join(dir, fmt.Sprintf("full-R%d-%x%s", algorithmRevision, seed[:8], endian))
+			os.Remove(path)
+		}
+	})
+}
+
+// finalizer closes any file handlers and memory maps open.
+func (d *dataset) finalizer() {
+	if d.mmap != nil {
+		d.mmap.Unmap()
+		d.dump.Close()
+		d.mmap, d.dump = nil, nil
+	}
+}
+
+// MakeCache generates a new ethash cache and optionally stores it to disk.
+func MakeCache(block uint64, dir string) {
+	c := cache{epoch: block / epochLength}
+	c.generate(dir, math.MaxInt32, false)
+}
+
+// MakeDataset generates a new ethash dataset and optionally stores it to disk.
+func MakeDataset(block uint64, dir string) {
+	d := dataset{epoch: block / epochLength}
+	d.generate(dir, math.MaxInt32, false)
+}
+
+// Mode defines the type and amount of PoW verification an ethash engine makes.
+type Mode uint
+
+const (
+	ModeNormal Mode = iota
+	ModeShared
+	ModeTest
+	ModeFake
+	ModeFullFake
+	ModeLocalMock
+)
+
+// Config are the configuration parameters of the ethash.
+type Config struct {
+	CacheDir       string
+	CachesInMem    int
+	CachesOnDisk   int
+	DatasetDir     string
+	DatasetsInMem  int
+	DatasetsOnDisk int
+	PowMode        Mode
+
+	CachesLockMmap   bool
+	DatasetsLockMmap bool
+}
+
+// Ethash is a pow engine based on proof-of-work implementing the ethash
+// algorithm.
+type Ethash struct {
+	config Config
+
+	caches   *lru // In memory caches to avoid regenerating too often
+	datasets *lru // In memory datasets to avoid regenerating too often
+
+	// Mining related fields
+	rand     *rand.Rand    // Properly seeded random source for nonces
+	threads  int           // Number of threads to mine on if mining
+	update   chan struct{} // Notification channel to update mining parameters
+	hashrate metrics.Meter // Meter tracking the average hashrate
+
+	// The fields below are hooks for testing
+	shared    *Ethash       // Shared PoW verifier to avoid cache regeneration
+	fakeFail  uint64        // Block number which fails PoW check even in fake mode
+	fakeDelay time.Duration // Time delay to sleep for before returning from verify
+
+	lock sync.Mutex // Ensures thread safety for the in-memory caches and mining fields
+}
+
+// New creates a full sized ethash PoW scheme.
+func New(config Config) *Ethash {
+	if config.CachesInMem <= 0 {
+		log.Warn("One ethash cache must always be in memory", "requested", config.CachesInMem)
+		config.CachesInMem = 1
+	}
+	if config.CacheDir != "" && config.CachesOnDisk > 0 {
+		log.Debug("Disk storage enabled for ethash caches", "dir", config.CacheDir, "count", config.CachesOnDisk)
+	}
+	if config.DatasetDir != "" && config.DatasetsOnDisk > 0 {
+		log.Debug("Disk storage enabled for ethash DAGs", "dir", config.DatasetDir, "count", config.DatasetsOnDisk)
+	}
+	//config.PowMode = ModeLocalMock
+	return &Ethash{
+		config:   config,
+		caches:   newlru("cache", config.CachesInMem, newCache),
+		datasets: newlru("dataset", config.DatasetsInMem, newDataset),
+		update:   make(chan struct{}),
+		hashrate: metrics.NewMeter(),
+	}
+}
+
+// NewTester creates a small sized ethash PoW scheme useful only for testing
+// purposes.
+func NewTester() *Ethash {
+	return New(Config{CachesInMem: 1, PowMode: ModeTest})
+}
+
+// NewFaker creates a ethash pow engine with a fake PoW scheme that accepts
+// all blocks' seal as valid, though they still have to conform to the Cypherium
+// pow rules.
+func NewFaker() *Ethash {
+	return &Ethash{
+		config: Config{
+			PowMode: ModeFake,
+		},
+	}
+}
+
+// NewFakeFailer creates a ethash pow engine with a fake PoW scheme that
+// accepts all blocks as valid apart from the single one specified, though they
+// still have to conform to the Cypherium pow rules.
+func NewFakeFailer(fail uint64) *Ethash {
+	return &Ethash{
+		config: Config{
+			PowMode: ModeFake,
+		},
+		fakeFail: fail,
+	}
+}
+
+// NewFakeDelayer creates a ethash pow engine with a fake PoW scheme that
+// accepts all blocks as valid, but delays verifications by some time, though
+// they still have to conform to the Cypherium pow rules.
+func NewFakeDelayer(delay time.Duration) *Ethash {
+	return &Ethash{
+		config: Config{
+			PowMode: ModeFake,
+		},
+		fakeDelay: delay,
+	}
+}
+
+// NewFullFaker creates an ethash pow engine with a full fake scheme that
+// accepts all blocks as valid, without checking any pow rules whatsoever.
+func NewFullFaker() *Ethash {
+	return &Ethash{
+		config: Config{
+			PowMode: ModeFullFake,
+		},
+	}
+}
+
+func NewNormal() *Ethash {
+	return &Ethash{
+		config: Config{
+			PowMode: ModeNormal,
+		},
+	}
+}
+
+// cache tries to retrieve a verification cache for the specified block number
+// by first checking against a list of in-memory caches, then against caches
+// stored on disk, and finally generating one if none can be found.
+func (ethash *Ethash) cache(block uint64) *cache {
+	epoch := block / epochLength
+	currentI, futureI := ethash.caches.get(epoch)
+	current := currentI.(*cache)
+
+	// Wait for generation finish.
+	current.generate(ethash.config.CacheDir, ethash.config.CachesOnDisk, ethash.config.PowMode == ModeTest)
+
+	// If we need a new future cache, now's a good time to regenerate it.
+	if futureI != nil {
+		future := futureI.(*cache)
+		go future.generate(ethash.config.CacheDir, ethash.config.CachesOnDisk, ethash.config.PowMode == ModeTest)
+	}
+	return current
+}
+
+// dataset tries to retrieve a mining dataset for the specified block number
+// by first checking against a list of in-memory datasets, then against DAGs
+// stored on disk, and finally generating one if none can be found.
+func (ethash *Ethash) dataset(block uint64) *dataset {
+	epoch := block / epochLength
+	currentI, futureI := ethash.datasets.get(epoch)
+	current := currentI.(*dataset)
+
+	// Wait for generation finish.
+	current.generate(ethash.config.DatasetDir, ethash.config.DatasetsOnDisk, ethash.config.PowMode == ModeTest)
+
+	// If we need a new future dataset, now's a good time to regenerate it.
+	if futureI != nil {
+		future := futureI.(*dataset)
+		go future.generate(ethash.config.DatasetDir, ethash.config.DatasetsOnDisk, ethash.config.PowMode == ModeTest)
+	}
+
+	return current
+}
+
+// Threads returns the number of mining threads currently enabled. This doesn't
+// necessarily mean that mining is running!
+func (ethash *Ethash) Threads() int {
+	ethash.lock.Lock()
+	defer ethash.lock.Unlock()
+
+	return ethash.threads
+}
+
+// SetThreads updates the number of mining threads currently enabled. Calling
+// this method does not start mining, only sets the thread count. If zero is
+// specified, the miner will use all cores of the machine. Setting a thread
+// count below zero is allowed and will cause the miner to idle, without any
+// work being done.
+func (ethash *Ethash) SetThreads(threads int) {
+	ethash.lock.Lock()
+	defer ethash.lock.Unlock()
+
+	// If we're running a shared PoW, set the thread count on that instead
+	if ethash.shared != nil {
+		ethash.shared.SetThreads(threads)
+		return
+	}
+	// Update the threads and ping any running seal to pull in any changes
+	ethash.threads = threads
+	select {
+	case ethash.update <- struct{}{}:
+	default:
+	}
+}
+
+// Hashrate implements PoW, returning the measured rate of the search invocations
+// per second over the last minute.
+func (ethash *Ethash) Hashrate() float64 {
+	return ethash.hashrate.Rate1()
+}
+
+// APIs implements pow.Engine, returning the user facing RPC APIs. Currently
+// that is empty.
+func (ethash *Ethash) APIs(chain consensus.ChainHeaderReader) []rpc.API {
+	return nil
+}
+
+func (ethash *Ethash) Close() error {
+	//??
+	return nil
+}
+
+// SeedHash is the seed to use for generating a verification cache and the mining
+// dataset.
+func SeedHash(block uint64) []byte {
+	return seedHash(block)
+}

--- a/consensus/colossusx/sealer.go
+++ b/consensus/colossusx/sealer.go
@@ -1,0 +1,156 @@
+// Copyright 2015 The go-ethereum Authors
+// Copyright 2017 The cypherBFT Authors
+// This file is part of the cypherBFT library.
+//
+// The cypherBFT library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The cypherBFT library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the cypherBFT library. If not, see <http://www.gnu.org/licenses/>.
+
+package ethash
+
+import (
+	crand "crypto/rand"
+	"math"
+	"math/big"
+	"math/rand"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/cypherium/cypher/common"
+	"github.com/cypherium/cypher/core/types"
+	"github.com/cypherium/cypher/log"
+)
+
+// SealCandidate implements pow.Engine, attempting to find a nonce that satisfies
+// the candidate's difficulty requirements.
+func (ethash *Ethash) SealCandidate(candidate *types.Candidate, stop <-chan struct{}) (*types.Candidate, error) {
+	log.Info("pow work,finding...", "PowMode", ethash.config.PowMode)
+	// If we're running a fake PoW, simply return a 0 nonce immediately
+	if ethash.config.PowMode == ModeFake || ethash.config.PowMode == ModeFullFake {
+		candidate.KeyCandidate.Nonce, candidate.KeyCandidate.MixDigest = types.BlockNonce{}, common.Hash{}
+		return candidate, nil
+	}
+	// Create a runner and the multiple search threads it directs
+	abort := make(chan struct{})
+	found := make(chan *types.Candidate)
+
+	ethash.lock.Lock()
+	threads := ethash.threads
+	if ethash.rand == nil {
+		seed, err := crand.Int(crand.Reader, big.NewInt(math.MaxInt64))
+		if err != nil {
+			ethash.lock.Unlock()
+			return nil, err
+		}
+		ethash.rand = rand.New(rand.NewSource(seed.Int64()))
+	}
+
+	ethash.lock.Unlock()
+	if threads == 0 {
+		threads = runtime.NumCPU()
+	}
+	if threads < 0 {
+		threads = 1
+	}
+	var pend sync.WaitGroup
+	for i := 0; i < threads; i++ {
+		pend.Add(1)
+		go func(id int, nonce uint64) {
+			defer pend.Done()
+			ethash.mineCandidate(candidate, id, nonce, abort, found)
+		}(i, uint64(ethash.rand.Int63()))
+	}
+	// Wait until sealing is terminated or a nonce is found
+	var result *types.Candidate
+	select {
+	case <-stop:
+		// Outside abort, stop all miner threads
+		close(abort)
+	case result = <-found:
+
+		// One of the threads found a block, abort all others
+		close(abort)
+	case <-ethash.update:
+		// Thread count was changed on user request, restart
+		close(abort)
+		pend.Wait()
+		log.Info("SealCandidate.update")
+		return ethash.SealCandidate(candidate, stop)
+	}
+	// Wait for all miners to terminate and return the block
+	pend.Wait()
+	return result, nil
+}
+
+// mineCandidate is the actual key-block Colossus proof-of-work miner that
+// searches for a nonce starting from seed that results in correct final block difficulty.
+func (ethash *Ethash) mineCandidate(candidate *types.Candidate, id int, seed uint64, abort chan struct{}, found chan *types.Candidate) {
+	// Extract some data from the header
+	var (
+		hash       = candidate.KeyCandidate.SealHash().Bytes()
+		target     = new(big.Int).Div(maxUint256, candidate.KeyCandidate.Difficulty)
+		number     = candidate.KeyCandidate.Number.Uint64()
+		dataset    = ethash.dataset(number)
+		scratchpad = colossusAcquireScratchpad()
+	)
+	defer colossusReleaseScratchpad(scratchpad)
+	// Start generating random nonces until we abort or find a good one
+	var (
+		attempts = int64(0)
+		nonce    = seed
+	)
+	log.Debug("mineCandidate", "seed", seed)
+	logger := log.New("miner", id)
+search:
+	for {
+		select {
+		case <-abort:
+			// Mining terminated, update stats and abort
+			logger.Trace("Ethash nonce search aborted", "attempts", nonce-seed)
+			ethash.hashrate.Mark(attempts)
+			break search
+
+		default:
+			// We don't have to update hash rate on every nonce, so update after after 2^X nonces
+			attempts++
+			if (attempts % (1 << 15)) == 0 {
+				ethash.hashrate.Mark(attempts)
+				attempts = 0
+			}
+			// Compute the PoW value of this nonce
+			digest, result := colossusHashFullWithScratchpad(scratchpad, dataset.dataset, hash, nonce)
+
+			if new(big.Int).SetBytes(result).Cmp(target) <= 0 {
+				foundedTime := time.Now().Unix()
+				foundedElapseTime := time.Duration(uint64(foundedTime)-candidate.KeyCandidate.Time) * time.Second
+				// Correct nonce found, create a new header with it
+				candidate.KeyCandidate.Nonce = types.EncodeNonce(nonce)
+				candidate.KeyCandidate.MixDigest = common.BytesToHash(digest)
+				log.Info("mineCandidate", "foundedElapseTime", foundedElapseTime, "nonce", candidate.KeyCandidate.Nonce, "digest", candidate.KeyCandidate.MixDigest)
+
+				// Seal and return a block (if still needed)
+				select {
+				case found <- candidate:
+					log.Info("Ethash nonce found and reported", "attempts", nonce-seed, "nonce", nonce)
+				case <-abort:
+					logger.Trace("Ethash nonce found but discarded", "attempts", nonce-seed, "nonce", nonce)
+				}
+				break search
+			}
+			nonce++
+		}
+	}
+	// Datasets are unmapped in a finalizer. Ensure that the dataset stays live
+	// during sealing so it's not unmapped while being read.
+	runtime.KeepAlive(dataset)
+}


### PR DESCRIPTION
### Motivation

- Provide a direct, byte-for-byte copy of the existing Ethash implementation into a new `consensus/colossusx` subtree so the code is available there for later integration without performing any refactors or renames.

### Description

- Created `consensus/colossusx` and added the following files copied exactly from `consensus/ethash`: `algorithm.go`, `colossus_test.go`, `consensus.go`, `ethash.go`, and `sealer.go`.
- Each copied file retains `package ethash`, all imports, comments, log strings, and content unchanged and was written verbatim (overwriting any existing same-named files in the destination).
- Did not modify or delete any files in `consensus/ethash`, did not touch `alias.go`, and performed no formatting, import/package renames, or reference switching.

### Testing

- Verified byte-for-byte equality using `cmp -s` for each pair (`consensus/ethash/*` vs `consensus/colossusx/*`), and all comparisons returned success (identical files).
- Committed the added files and confirmed the commit contains the five new files using `git show --name-only HEAD`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5a423dd448330ba3c1a1db4c8ca97)