### PR TITLE
Change package declarations to `colossusx` in consensus/colossusx files

### DIFF
--- a/consensus/colossusx/algorithm.go
+++ b/consensus/colossusx/algorithm.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the cypherBFT library. If not, see <http://www.gnu.org/licenses/>.
 
-package ethash
+package colossusx
 
 import (
 	"encoding/binary"

--- a/consensus/colossusx/colossus_test.go
+++ b/consensus/colossusx/colossus_test.go
@@ -1,4 +1,4 @@
-package ethash
+package colossusx
 
 import (
 	"encoding/hex"

--- a/consensus/colossusx/consensus.go
+++ b/consensus/colossusx/consensus.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the cypherBFT library. If not, see <http://www.gnu.org/licenses/>.
 
-package ethash
+package colossusx
 
 import (
 	"bytes"

--- a/consensus/colossusx/ethash.go
+++ b/consensus/colossusx/ethash.go
@@ -17,7 +17,7 @@
 
 // Package ethash implements the ethash proof-of-work pow engine.
 
-package ethash
+package colossusx
 
 import (
 	"errors"

--- a/consensus/colossusx/sealer.go
+++ b/consensus/colossusx/sealer.go
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the cypherBFT library. If not, see <http://www.gnu.org/licenses/>.
 
-package ethash
+package colossusx
 
 import (
 	crand "crypto/rand"


### PR DESCRIPTION
### Motivation
- Ensure the package declarations match the `consensus/colossusx` package by replacing incorrect `package ethash` lines with `package colossusx` in the colossusx consensus files.

### Description
- Replaced the top-level `package ethash` declaration with `package colossusx` in `consensus/colossusx/algorithm.go`, `consensus/colossusx/colossus_test.go`, `consensus/colossusx/consensus.go`, `consensus/colossusx/ethash.go`, and `consensus/colossusx/sealer.go`.
- No other code or API changes were made in these files.

### Testing
- Verified the package declarations with `rg -n "^package "` across the five modified files and confirmed each now reports `package colossusx`.
- No runtime or unit tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c63f4c88e883309f530e408851facf)