### PR TITLE
Use ChainConfig helper for future-block timestamp checks

### DIFF
--- a/core/keyblockchain.go
+++ b/core/keyblockchain.go
@@ -571,7 +571,7 @@ func (kbc *KeyBlockChain) ValidateKeyBlock(block *types.KeyBlock) error {
 	if header.Time <= parent.Time {
 		return fmt.Errorf("invalid keyblock timestamp: parent %d, current %d", parent.Time, header.Time)
 	}
-	if header.Time > uint64(time.Now().Unix())+kbc.chainConfig.AllowedFutureBlockTime {
+	if header.Time > uint64(time.Now().Unix())+kbc.chainConfig.AllowedFutureBlockTime() {
 		return types.ErrFutureBlock
 	}
 	expectedDiff := kbc.engine.CalcKeyBlockDifficulty(kbc, header.Time, parent)

--- a/params/config.go
+++ b/params/config.go
@@ -369,6 +369,19 @@ type ChainConfig struct {
 }
 type GenesisCommittee map[int]common.Cnode
 
+// AllowedFutureBlockTime returns the maximum number of seconds a block timestamp
+// may be ahead of the local clock before it is considered a future block.
+// If a clique-specific value is configured, use that. Otherwise default to 5 minutes.
+func (c *ChainConfig) AllowedFutureBlockTime() uint64 {
+	if c == nil {
+		return 5 * 60
+	}
+	if c.Clique != nil && c.Clique.AllowedFutureBlockTime > 0 {
+		return c.Clique.AllowedFutureBlockTime
+	}
+	return 5 * 60
+}
+
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
 type EthashConfig struct{}
 


### PR DESCRIPTION
### Motivation
- Centralize and default the logic that determines how far a block timestamp may be ahead of the local clock, ensuring a safe fallback when the chain config or clique sub-config is unset.

### Description
- Add `(*ChainConfig).AllowedFutureBlockTime()` in `params/config.go` which returns the clique-configured `AllowedFutureBlockTime` when present, otherwise returns a 5 minute default and safely handles a `nil` `ChainConfig`.
- Update key-block validation in `core/keyblockchain.go` to call `kbc.chainConfig.AllowedFutureBlockTime()` instead of directly accessing the `Clique` field.

### Testing
- Ran `go test ./params ./core` which failed due to repository layout lacking a Go module (error: `go: cannot find main module`), so no package tests executed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c657813c7c8330b33528250f6ee513)