### PR TITLE
Set ColossusX epoch length to 16166 blocks

### DIFF
--- a/consensus/colossusx/algorithm.go
+++ b/consensus/colossusx/algorithm.go
@@ -39,7 +39,7 @@ const (
 	datasetGrowthBytes = 1 << 23 // Dataset growth per epoch
 	cacheInitBytes     = 1 << 26 // Bytes in cache at genesis
 	cacheGrowthBytes   = 1 << 17 // Cache growth per epoch
-	epochLength        = 30000   // Blocks per epoch
+	epochLength        = 16166   // Blocks per epoch
 	mixBytes           = 128     // Width of mix
 	hashBytes          = 64      // Hash length in bytes
 	hashWords          = 16      // Number of 32 bit ints in a hash


### PR DESCRIPTION
### Motivation
- Update consensus parameter to set `epochLength` to `16166` blocks to align the ColossusX epoch duration with the new protocol/network timing.

### Description
- Change constant `epochLength` from `30000` to `16166` in `consensus/colossusx/algorithm.go`.

### Testing
- Ran unit tests with `go test ./...` and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c67049ecc483308b5d0ea1f6cff5ef)