### PR TITLE
consensus/colossusx: add deterministic key-header sealing helper

### DIFF
--- a/consensus/colossusx/sealer.go
+++ b/consensus/colossusx/sealer.go
@@ -92,6 +92,37 @@ func (ethash *Ethash) SealCandidate(candidate *types.Candidate, stop <-chan stru
 	return result, nil
 }
 
+func (ethash *Ethash) SealKeyHeaderDeterministic(header *types.KeyBlockHeader, startNonce uint64) error {
+	if header == nil || header.Number == nil || header.Difficulty == nil || header.Difficulty.Sign() <= 0 {
+		return errInvalidDifficulty
+	}
+	if ethash.config.PowMode == ModeFake || ethash.config.PowMode == ModeFullFake {
+		header.Nonce = types.EncodeNonce(startNonce)
+		header.MixDigest = common.Hash{}
+		return nil
+	}
+
+	number := header.Number.Uint64()
+	hash := header.SealHash().Bytes()
+	target := new(big.Int).Div(maxUint256, header.Difficulty)
+
+	dataset := ethash.dataset(number)
+	scratchpad := colossusAcquireScratchpad()
+	defer func() {
+		colossusReleaseScratchpad(scratchpad)
+		runtime.KeepAlive(dataset)
+	}()
+
+	for nonce := startNonce; ; nonce++ {
+		digest, result := colossusHashFullWithScratchpad(scratchpad, dataset.dataset, hash, nonce)
+		if new(big.Int).SetBytes(result).Cmp(target) <= 0 {
+			header.Nonce = types.EncodeNonce(nonce)
+			header.MixDigest = common.BytesToHash(digest)
+			return nil
+		}
+	}
+}
+
 // mineCandidate is the actual key-block Colossus proof-of-work miner that
 // searches for a nonce starting from seed that results in correct final block difficulty.
 func (ethash *Ethash) mineCandidate(candidate *types.Candidate, id int, seed uint64, abort chan struct{}, found chan *types.Candidate) {


### PR DESCRIPTION
### Motivation
- Provide a deterministic sealing helper to find a valid nonce for a key block header starting from a given nonce. 
- Ensure input validation and correct resource lifecycle handling to avoid dataset finalizer races during deterministic sealing.

### Description
- Add `SealKeyHeaderDeterministic(header *types.KeyBlockHeader, startNonce uint64) error` which validates `header`/`Number`/`Difficulty` and returns `errInvalidDifficulty` for invalid inputs. 
- Support fake PoW modes by assigning `startNonce` to `header.Nonce` and setting `header.MixDigest` to a zero hash for `ModeFake` and `ModeFullFake`. 
- Perform a deterministic nonce search starting at `startNonce` using `colossusHashFullWithScratchpad` against the dataset and set `Nonce`/`MixDigest` when the target is met. 
- Manage scratchpad/dataset lifecycle by releasing the scratchpad and calling `runtime.KeepAlive(dataset)` to prevent dataset unmapping during sealing.

### Testing
- Ran `gofmt -w consensus/colossusx/sealer.go`, which completed successfully. 
- Attempted `go test ./consensus/colossusx`, which failed in this repository layout with `cannot find main module` because no `go.mod` is present at the repository root.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6b065dad483309111b08dc499a00a)