### PR TITLE
core: skip genesis header seal self-check on startup

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -333,8 +333,13 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	if !ok {
 		return nil, fmt.Errorf("consensus engine does not support header seal verification")
 	}
-	if err := sealVerifier.VerifyHeaderSeal(bc.CurrentHeader()); err != nil {
-		return nil, err
+	currentHeader := bc.CurrentHeader()
+	if currentHeader.Number != nil && currentHeader.Number.Uint64() == 0 {
+		log.Info("Skipping genesis tx block seal self-check", "hash", currentHeader.Hash())
+	} else {
+		if err := sealVerifier.VerifyHeaderSeal(currentHeader); err != nil {
+			return nil, err
+		}
 	}
 
 	// Check the current state of the block hashes and make sure that we do not have any of the bad blocks in our chain


### PR DESCRIPTION
### Motivation
- Prevent performing the header seal self-check on the genesis header during startup by caching and inspecting the current header before calling the consensus `VerifyHeaderSeal` self-check in `NewBlockChain`.

### Description
- Cache `bc.CurrentHeader()` into a local variable and if its `Number` equals `0` skip calling `sealVerifier.VerifyHeaderSeal(...)` and emit an info log, otherwise preserve the existing verification path.

### Testing
- Ran `go test ./core -run TestDoesNotExist`, which failed in this environment because the repository is not configured as a Go module (`go: cannot find main module`), so no package tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c737dc1c8330a3f06b094eb39bf5)