### PR TITLE
params: rename Ethash engine string to colossusx and simplify ChainConfig String output

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -387,7 +387,7 @@ type EthashConfig struct{}
 
 // String implements the stringer interface, returning the consensus engine details.
 func (c *EthashConfig) String() string {
-	return "ethash"
+	return "colossusx"
 }
 
 // CliqueConfig is the consensus engine configs for proof-of-authority based sealing.
@@ -427,7 +427,7 @@ func (c *ChainConfig) String() string {
 	default:
 		engine = "unknown"
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v HasPrivate: %v Constantinople: %v TransactionSizeLimit: %v MaxCodeSize: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v YOLO v1: %v PrivacyEnhancements: %v Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v HasPrivate: %v Constantinople: %v TransactionSizeLimit: %v MaxCodeSize: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v YOLO v1: %v Engine: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,


### PR DESCRIPTION
### Motivation
- Rename the Ethash engine string to reflect a new/alternate engine name (branding or protocol change) and reduce verbosity in the chain config string used for logging or debugging.
- Remove an unused/obsolete `PrivacyEnhancements` label from the `ChainConfig.String()` output to keep the human-readable representation concise.

### Description
- Change `EthashConfig.String()` return value from `"ethash"` to `"colossusx"` in `params/config.go`.
- Simplify the `fmt.Sprintf` format string in `ChainConfig.String()` by removing the `PrivacyEnhancements: %v` field while keeping the `Engine` value in the output.
- The modifications are confined to `params/config.go` and were committed to the current branch.

### Testing
- Ran `go test ./params`, which failed due to repository layout missing a Go module (error: `cannot find main module`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6ca8485c48330acd7360b61dfef84)