### PR TITLE
Fix colossusx dataset generation logging and progress calculation

### DIFF
--- a/consensus/colossusx/algorithm.go
+++ b/consensus/colossusx/algorithm.go
@@ -307,7 +307,7 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 		if elapsed > 3*time.Second {
 			logFn = logger.Info
 		}
-		logFn("Generated colossusx verification cache", "elapsed", common.PrettyDuration(elapsed))
+		logFn("Generated colossusx dataset", "elapsed", common.PrettyDuration(elapsed))
 	}()
 
 	// Figure out whether the bytes need to be swapped for the machine
@@ -342,7 +342,11 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 				limit = uint32(size / hashBytes)
 			}
 			// Calculate the dataset segment
-			percent := uint32(size / hashBytes / 100)
+			totalItems := size / hashBytes
+			percent := uint32(totalItems / 100)
+			if percent == 0 {
+				percent = 1
+			}
 			for index := first; index < limit; index++ {
 				item := generateDatasetItem(cache, index, keccak512)
 				if swapped {
@@ -351,7 +355,9 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 				copy(dataset[index*hashBytes:], item)
 
 				if status := atomic.AddUint32(&progress, 1); status%percent == 0 {
-					logger.Info("Generating DAG in progress", "percentage", uint64(status*100)/(size/hashBytes), "elapsed", common.PrettyDuration(time.Since(start)))
+					logger.Info("Generating DAG in progress",
+						"percentage", (uint64(status)*100)/totalItems,
+						"elapsed", common.PrettyDuration(time.Since(start)))
 				}
 			}
 		}(i)


### PR DESCRIPTION
### Motivation
- The dataset generation progress logging referenced the wrong entity and could report incorrect progress intervals when the dataset is very small. 

### Description
- Updated the completion log in `generateDataset` to read "Generated colossusx dataset" so the message reflects the actual operation. 
- Hardened progress interval computation by introducing `totalItems := size / hashBytes`, computing `percent := uint32(totalItems / 100)`, and clamping `percent` to `1` to avoid modulo-by-zero. 
- Replaced the previous percentage expression with a clearer calculation using `totalItems` when logging progress.

### Testing
- Attempted to run `go test ./consensus/colossusx`, which failed in this repository layout with the error: "cannot find main module" because no Go module is defined at the repository root.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6d236eeb08330b5a91e0d0831069f)