### PR TITLE
Rename Ethash log labels in Colossusx sealer

### DIFF
--- a/consensus/colossusx/sealer.go
+++ b/consensus/colossusx/sealer.go
@@ -147,7 +147,7 @@ search:
 		select {
 		case <-abort:
 			// Mining terminated, update stats and abort
-			logger.Trace("Ethash nonce search aborted", "attempts", nonce-seed)
+			logger.Trace("Colossusx nonce search aborted", "attempts", nonce-seed)
 			ethash.hashrate.Mark(attempts)
 			break search
 
@@ -172,9 +172,9 @@ search:
 				// Seal and return a block (if still needed)
 				select {
 				case found <- candidate:
-					log.Info("Ethash nonce found and reported", "attempts", nonce-seed, "nonce", nonce)
+					log.Info("Colossusx nonce found and reported", "attempts", nonce-seed, "nonce", nonce)
 				case <-abort:
-					logger.Trace("Ethash nonce found but discarded", "attempts", nonce-seed, "nonce", nonce)
+					logger.Trace("Colossusx nonce found but discarded", "attempts", nonce-seed, "nonce", nonce)
 				}
 				break search
 			}


### PR DESCRIPTION
### Motivation
- Replace incorrect `Ethash` references in Colossusx sealer logs to avoid misleading output and align log messages with the Colossusx consensus engine.

### Description
- Updated three log strings in `consensus/colossusx/sealer.go` inside `mineCandidate`: changed `"Ethash nonce search aborted"` to `"Colossusx nonce search aborted"`, `"Ethash nonce found and reported"` to `"Colossusx nonce found and reported"`, and `"Ethash nonce found but discarded"` to `"Colossusx nonce found but discarded"`.

### Testing
- Ran `git -C /workspace/cypher diff -- consensus/colossusx/sealer.go` and `git -C /workspace/cypher status --short` and created a commit; these checks completed successfully and no unit/integration tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6d8a30df4833086e6162c002f01b2)