### PR TITLE
bftview: fall back to committee without IP in GetCurrentMember

### DIFF
--- a/reconfig/bftview/committee.go
+++ b/reconfig/bftview/committee.go
@@ -199,6 +199,9 @@ func GetCurrentMember() *Committee {
 	curBlock := m_config.keyblockchain.CurrentBlock()
 	c := LoadMember(curBlock.NumberU64(), curBlock.Hash(), true)
 	if c == nil {
+		c = LoadMember(curBlock.NumberU64(), curBlock.Hash(), false)
+	}
+	if c == nil {
 		//log.Error("Committee.GetCurrent", "Roster or list is nil, keyblock number", curBlock.NumberU64())
 		return nil
 	}


### PR DESCRIPTION
### Motivation
- Ensure `GetCurrentMember` can return a committee even when stored entries lack IP metadata by trying a less strict load path.
- Improve resilience when cached or on-disk committee entries do not include IPs so the node can still proceed with committee data.

### Description
- Call `LoadMember(curBlock.NumberU64(), curBlock.Hash(), true)` first and fall back to `LoadMember(..., false)` when it returns `nil` in `GetCurrentMember`.
- Preserve the existing nil-guard and return `nil` only when both lookup attempts fail.

### Testing
- Ran `go test ./reconfig/bftview` and it failed due to repository layout (`go: cannot find main module`), so no package tests executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6d8c9fe4483308f7428f12bbbe66d)