### PR TITLE
Require IP-aware committee in GetCurrentMember

### DIFF
--- a/reconfig/bftview/committee.go
+++ b/reconfig/bftview/committee.go
@@ -199,9 +199,6 @@ func GetCurrentMember() *Committee {
 	curBlock := m_config.keyblockchain.CurrentBlock()
 	c := LoadMember(curBlock.NumberU64(), curBlock.Hash(), true)
 	if c == nil {
-		c = LoadMember(curBlock.NumberU64(), curBlock.Hash(), false)
-	}
-	if c == nil {
 		//log.Error("Committee.GetCurrent", "Roster or list is nil, keyblock number", curBlock.NumberU64())
 		return nil
 	}


### PR DESCRIPTION
### Motivation
- Ensure `GetCurrentMember` only returns a committee that includes IP information by removing the fallback that loaded a committee without IPs.

### Description
- Removed the fallback call to `LoadMember(..., false)` in `GetCurrentMember`, so the function now returns `nil` if `LoadMember(..., true)` fails.

### Testing
- Ran `go test ./reconfig/bftview`, which failed in this environment due to a missing Go module at the repository root (`cannot find main module`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6e5a0bc308330903da1221b28563d)