### PR TITLE
consensus/colossusx: increase genesis dataset size to 32 GiB

### DIFF
--- a/consensus/colossusx/algorithm.go
+++ b/consensus/colossusx/algorithm.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	datasetInitBytes   = 1 << 32 // Bytes in dataset at genesis
+	datasetInitBytes   = 1 << 35 // 32 GiB at genesis
 	datasetGrowthBytes = 64 * 1024 * 1024 // Dataset growth per epoch
 	cacheInitBytes     = 1 << 26 // Bytes in cache at genesis
 	cacheGrowthBytes   = 1 << 17 // Cache growth per epoch


### PR DESCRIPTION
### Motivation
- Increase the ColossusX genesis dataset size constant to reflect a 32 GiB starting dataset for mining/dataset calculations.

### Description
- Changed `datasetInitBytes` in `consensus/colossusx/algorithm.go` from `1 << 32` to `1 << 35` and updated the inline comment to `// 32 GiB at genesis`.

### Testing
- Ran `go test ./consensus/colossusx`, which failed in this environment with `cannot find main module` because the repository is not initialized as a Go module, so package tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6f52579408330bc11011f7f7130f6)