### PR TITLE
Fix duplicate registration of aliased CLI flags

### DIFF
--- a/cmd/utils/customflags.go
+++ b/cmd/utils/customflags.go
@@ -61,7 +61,7 @@ func (f DirectoryFlag) String() string {
 // and adds variable to flag set for parsing.
 func (f DirectoryFlag) Apply(set *flag.FlagSet) {
 	eachName(f.Name, func(name string) {
-		set.Var(&f.Value, f.Name, f.Usage)
+		set.Var(&f.Value, name, f.Usage)
 	})
 }
 
@@ -121,7 +121,7 @@ func (f TextMarshalerFlag) String() string {
 
 func (f TextMarshalerFlag) Apply(set *flag.FlagSet) {
 	eachName(f.Name, func(name string) {
-		set.Var(textMarshalerVal{f.Value}, f.Name, f.Usage)
+		set.Var(textMarshalerVal{f.Value}, name, f.Usage)
 	})
 }
 
@@ -172,7 +172,7 @@ func (f BigFlag) String() string {
 
 func (f BigFlag) Apply(set *flag.FlagSet) {
 	eachName(f.Name, func(name string) {
-		set.Var((*bigValue)(f.Value), f.Name, f.Usage)
+		set.Var((*bigValue)(f.Value), name, f.Usage)
 	})
 }
 


### PR DESCRIPTION
### Motivation
- Prevent a panic caused by re-registering the same comma-separated flag name (e.g. `colossusx.cachedir,ethash.cachedir`) multiple times when aliases are expanded.
- The available skills were not used because the change is a straightforward code fix inside the repo and does not require any skill workflows.

### Description
- Changed `cmd/utils/customflags.go` so `Apply` registers each alias name with `set.Var` instead of repeatedly passing the combined `f.Name` string.
- Updated `DirectoryFlag.Apply` to call `set.Var(&f.Value, name, f.Usage)` for each alias instead of `f.Name`.
- Updated `TextMarshalerFlag.Apply` to call `set.Var(textMarshalerVal{f.Value}, name, f.Usage)` for each alias instead of `f.Name`.
- Updated `BigFlag.Apply` to call `set.Var((*bigValue)(f.Value), name, f.Usage)` for each alias instead of `f.Name`.

### Testing
- Ran `go test ./cmd/utils` but it could not run in this environment because the repository is not configured as a Go module (`go: cannot find main module`).
- Ran `GO111MODULE=off go test ./cmd/utils`, which failed to build due to missing packages under the container GOPATH (project layout / dependencies not available in the test environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c76cbd2c648330937bd1e572871b79)