### PR TITLE
Rename residual Ethash runtime labels to Colossusx

### DIFF
--- a/consensus/colossusx/ethash.go
+++ b/consensus/colossusx/ethash.go
@@ -190,7 +190,7 @@ func (lru *lru) get(epoch uint64) (item, future interface{}) {
 	}
 	// Update the 'future item' if epoch is larger than previously seen.
 	if epoch < maxEpoch-1 && lru.future < epoch+1 {
-		log.Trace("Requiring new future ethash "+lru.what, "epoch", epoch+1)
+		log.Trace("Requiring new future colossusx "+lru.what, "epoch", epoch+1)
 		future = lru.new(epoch + 1)
 		lru.future = epoch + 1
 		lru.futureItem = future
@@ -246,12 +246,12 @@ func (c *cache) generate(dir string, limit int, test bool) {
 			logger.Debug("Loaded old colossusx cache from disk")
 			return
 		}
-		logger.Debug("Failed to load old ethash cache", "err", err)
+		logger.Debug("Failed to load old colossusx cache", "err", err)
 
 		// No previous cache available, create a new cache file to fill
 		c.dump, c.mmap, c.cache, err = memoryMapAndGenerate(path, size, func(buffer []uint32) { generateCache(buffer, c.epoch, seed) })
 		if err != nil {
-			logger.Error("Failed to generate mapped ethash cache", "err", err)
+			logger.Error("Failed to generate mapped colossusx cache", "err", err)
 
 			c.cache = make([]uint32, size/4)
 			generateCache(c.cache, c.epoch, seed)
@@ -327,7 +327,7 @@ func (d *dataset) generate(dir string, limit int, test bool) {
 			logger.Debug("Loaded old colossusx dataset from disk")
 			return
 		}
-		logger.Debug("Failed to load old ethash dataset", "err", err)
+		logger.Debug("Failed to load old colossusx dataset", "err", err)
 
 		// No previous dataset available, create a new dataset file to fill
 		cache := make([]uint32, csize/4)
@@ -335,7 +335,7 @@ func (d *dataset) generate(dir string, limit int, test bool) {
 
 		d.dump, d.mmap, d.dataset, err = memoryMapAndGenerate(path, dsize, func(buffer []uint32) { generateDataset(buffer, d.epoch, cache) })
 		if err != nil {
-			logger.Error("Failed to generate mapped ethash dataset", "err", err)
+			logger.Error("Failed to generate mapped colossusx dataset", "err", err)
 
 			d.dataset = make([]uint32, dsize/4)
 			generateDataset(d.dataset, d.epoch, cache)
@@ -425,7 +425,7 @@ func New(config Config) *Ethash {
 		config.CachesInMem = 1
 	}
 	if config.CacheDir != "" && config.CachesOnDisk > 0 {
-		log.Debug("Disk storage enabled for ethash caches", "dir", config.CacheDir, "count", config.CachesOnDisk)
+		log.Debug("Disk storage enabled for colossusx caches", "dir", config.CacheDir, "count", config.CachesOnDisk)
 	}
 	if config.DatasetDir != "" && config.DatasetsOnDisk > 0 {
 		log.Debug("Disk storage enabled for colossusx datasets", "dir", config.DatasetDir, "count", config.DatasetsOnDisk)

--- a/eth/config.go
+++ b/eth/config.go
@@ -49,7 +49,7 @@ var DefaultLightGPOConfig = gasprice.Config{
 var DefaultConfig = Config{
 	SyncMode: downloader.FastSync,
 	Colossusx: colossusx.Config{
-		CacheDir:         "ethash",
+		CacheDir:         "colossusx",
 		CachesInMem:      2,
 		CachesOnDisk:     3,
 		CachesLockMmap:   false,
@@ -87,16 +87,16 @@ func init() {
 		}
 	}
 	if runtime.GOOS == "darwin" {
-		DefaultConfig.Colossusx.DatasetDir = filepath.Join(home, "Library", "Ethash")
+		DefaultConfig.Colossusx.DatasetDir = filepath.Join(home, "Library", "Colossusx")
 	} else if runtime.GOOS == "windows" {
 		localappdata := os.Getenv("LOCALAPPDATA")
 		if localappdata != "" {
-			DefaultConfig.Colossusx.DatasetDir = filepath.Join(localappdata, "Ethash")
+			DefaultConfig.Colossusx.DatasetDir = filepath.Join(localappdata, "Colossusx")
 		} else {
-			DefaultConfig.Colossusx.DatasetDir = filepath.Join(home, "AppData", "Local", "Ethash")
+			DefaultConfig.Colossusx.DatasetDir = filepath.Join(home, "AppData", "Local", "Colossusx")
 		}
 	} else {
-		DefaultConfig.Colossusx.DatasetDir = filepath.Join(home, ".ethash")
+		DefaultConfig.Colossusx.DatasetDir = filepath.Join(home, ".colossusx")
 	}
 	DefaultConfig.Ethash = DefaultConfig.Colossusx
 }


### PR DESCRIPTION
### Motivation
- Ensure runtime logs and default paths consistently use `colossusx` instead of legacy `ethash` to avoid confusion during mining and DAG/cache generation.
- Prevent new nodes from creating directories like `~/.ethash` and emitting `ethash` runtime messages when the codebase is aligned to Colossusx naming.

### Description
- Replace residual `ethash` labels in `consensus/colossusx/ethash.go` with `colossusx` in log messages such as `Failed to load old ...`, `Failed to generate mapped ...`, and future-item trace lines.
- Update default cache/dataset directory names in `eth/config.go` from `ethash` to `colossusx` for Linux (`~/.colossusx`), macOS (`~/Library/Colossusx`) and Windows (`%LOCALAPPDATA%/Colossusx`).
- Commit message: `Rename remaining ethash labels to colossusx in PoW logs/config` (changes staged and committed).

### Testing
- Ran `go test ./consensus/colossusx ./eth`, which failed due to the environment not having a Go module setup (`go: cannot find main module`).
- Ran `GO111MODULE=off go test ./consensus/colossusx`, which failed because GOPATH dependencies are not available in this environment. 
- Verified with searches (`rg`) and repository diffs that previous `ethash` runtime strings/paths were removed from the modified files, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c77434ac2c8330af312cf402b64df3)