### PR TITLE
Add genesis file for Colx local network (`genesis-colx.json`)

### DIFF
--- a/cmd/cypher/genesis-colx.json
+++ b/cmd/cypher/genesis-colx.json
@@ -1,0 +1,32 @@
+{
+  "config": {
+    "chainId": 1337,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "committee": {
+      "0": {
+        "address": "127.0.0.1:7102",
+        "coinbase": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "public": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      }
+    }
+  },
+  "alloc": {
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+      "balance": "1000000000000000000000000"
+    },
+    "cccccccccccccccccccccccccccccccccccccccc": {
+      "balance": "1000000000000000000000000"
+    }
+  },
+  "difficulty": "0x1",
+  "gasLimit": "0xE0000000",
+  "nonce": "0x0",
+  "mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "timestamp": "0x00"
+}


### PR DESCRIPTION
### Motivation
- Provide a genesis configuration for a local Colx/dev network so nodes can be initialized with a known chain ID, committee entry, and pre-funded accounts.

### Description
- Add `cmd/cypher/genesis-colx.json` which sets `chainId` to `1337`, enables pre-EIP blocks (all set to `0`), includes a `committee` entry for `127.0.0.1:7102` with placeholder `coinbase` and `public` keys, allocates two pre-funded accounts, and supplies genesis metadata (`difficulty`, `gasLimit`, `nonce`, `mixhash`, `parentHash`, and `timestamp`).

### Testing
- Ran repository unit tests with `go test ./...` which completed successfully and validated that adding the new JSON file did not break the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c81b743eb08330a724e7d826660b06)