### PR TITLE
Disable cypherBFT membership gating for colossusx mining

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -13,14 +13,12 @@ import (
 	"github.com/cypherium/cypher/common"
 	"github.com/cypherium/cypher/core"
 	"github.com/cypherium/cypher/core/types"
-	"github.com/cypherium/cypher/reconfig/bftview"
 
 	"github.com/cypherium/cypher/consensus"
 	"github.com/cypherium/cypher/consensus/colossusx"
 	"github.com/cypherium/cypher/ethdb"
 	"github.com/cypherium/cypher/event"
 	"github.com/cypherium/cypher/log"
-	"github.com/cypherium/cypher/p2p/netutil"
 	"github.com/cypherium/cypher/params"
 )
 
@@ -129,12 +127,6 @@ func (self *worker) start() {
 	if atomic.LoadInt32(&self.running) == 1 {
 		return
 	}
-	port, _ := strconv.Atoi(self.config.RnetPort)
-	err := netutil.VerifyConnectivity("udp", net.ParseIP("127.0.0.1"), port)
-	if err != nil {
-		log.Error("Your node haven't opened UDP consensus port.So POW work is not to permit", "The port is", port)
-		return
-	}
 
 	atomic.StoreInt32(&self.running, 1)
 	self.keyHeadSub = self.eth.KeyBlockChain().SubscribeChainEvent(self.keyHeadCh)
@@ -185,28 +177,24 @@ func (self *worker) unregister(agent Agent) {
 
 func (self *worker) autoCommit() {
 	log.Info("Miner worker start auto-committing")
-	if bftview.IamMember() < 0 {
-		self.commitNewWork()
-	}
+	self.commitNewWork()
 
 	for {
 		select {
 		case <-self.keyHeadCh:
-			if bftview.IamMember() < 0 {
-				self.commitNewWork()
-				self.stop()
+			self.commitNewWork()
+			self.stop()
 
-				shouldStart := atomic.LoadInt32(&self.shouldStart) == 1
-				if shouldStart {
-					if !self.isRunning() {
-						log.Info("Restore,Ready to start pow work")
-						self.start() //now action
-					}
+			shouldStart := atomic.LoadInt32(&self.shouldStart) == 1
+			if shouldStart {
+				if !self.isRunning() {
+					log.Info("Restore,Ready to start pow work")
+					self.start() //now action
+				}
 
-				} else {
-					if !shouldStart {
-						log.Info("User has not permitted  to start")
-					}
+			} else {
+				if !shouldStart {
+					log.Info("User has not permitted  to start")
 				}
 			}
 


### PR DESCRIPTION
### Motivation
- Allow the miner to run colossusx-only mining and produce blocks without requiring cypherBFT committee membership or UDP consensus-port connectivity checks.

### Description
- Removed `reconfig/bftview` and `p2p/netutil` usage from `miner/worker.go` and deleted membership gating based on `bftview.IamMember()` so work is prepared regardless of BFT membership.
- Removed the UDP connectivity verification in `worker.start()` so mining can start without a dedicated consensus UDP port check.
- Updated `autoCommit()` to always call `commitNewWork()` on key-head events and kept the existing stop/start `shouldStart` flow.
- Adjusted imports and logic in `miner/worker.go` to reflect the above (work generation now runs unconditionally for `colossusx`).

### Testing
- Ran formatting with `gofmt -w miner/worker.go` (succeeded).
- Attempted `go test ./miner` and `GO111MODULE=off go test ./miner`, both failed in this environment due to missing module/GOPATH dependency configuration and not because of the edited file itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c84c14b6588330b3c6b9ca2c48a853)