### PR TITLE
consensus/colossusx: add prod-like benchmarks and benchmarking runbook

### DIFF
--- a/consensus/colossusx/BENCHMARKING.md
+++ b/consensus/colossusx/BENCHMARKING.md
@@ -1,0 +1,82 @@
+# ColossusX prod-like benchmark runbook
+
+This runbook separates **cold** and **warm** measurements so numbers are easier to interpret.
+
+- **cold**: include first-time cache/dataset generation (or first-time write to benchmark directory)
+- **warm**: pre-generated cache/dataset exists and benchmark mostly measures mmap/open + hash/verify paths
+
+## 1) Recommended commands
+
+> These commands assume you run from repository root.
+
+### A. Warm-up step (create benchmark artifacts once)
+
+```bash
+go test ./consensus/colossusx -run '^$' -bench '^Benchmark(CacheInit_ProdLike_Cold|DatasetInit_ProdLike_Cold)$' -benchtime=1x -count=1 -benchmem
+```
+
+### B. Cold benchmarks (single-shot latency)
+
+```bash
+go test ./consensus/colossusx -run '^$' -bench '^Benchmark(CacheInit_ProdLike_Cold|DatasetInit_ProdLike_Cold)$' -benchtime=1x -count=3 -benchmem
+```
+
+### C. Warm init benchmarks (load existing cache/dataset from disk)
+
+```bash
+go test ./consensus/colossusx -run '^$' -bench '^Benchmark(CacheInit_ProdLike_Warm|DatasetInit_ProdLike_Warm)$' -benchtime=3x -count=5 -benchmem
+```
+
+### D. Warm steady-state PoW path benchmarks
+
+```bash
+go test ./consensus/colossusx -run '^$' -bench '^Benchmark(ColossusHashLight_ProdLike|ColossusHashFullWithScratchpad_ProdLike|VerifyHeaderSeal_ProdLike|VerifyKeyHeaderSeal_ProdLike)$' -benchtime=2s -count=5 -benchmem
+```
+
+### E. Warm parallel throughput benchmarks
+
+```bash
+go test ./consensus/colossusx -run '^$' -bench '^Benchmark(ColossusHashLight_ProdLike_Parallel|ColossusHashFullWithScratchpad_ProdLike_Parallel|VerifyHeaderSeal_ProdLike_Parallel)$' -benchtime=2s -count=5 -benchmem
+```
+
+## 2) Reading benchmark output
+
+Typical line:
+
+```text
+BenchmarkVerifyHeaderSeal_ProdLike-32     12000    95000 ns/op    0 B/op    0 allocs/op
+```
+
+- **ns/op**: average nanoseconds per operation (lower is better)
+- **B/op**: average heap bytes allocated per operation (lower is better)
+- **allocs/op**: average number of heap allocations per operation (lower is better)
+
+### Quick conversions
+
+- `1,000,000 ns/op = 1 ms/op`
+- Throughput estimate (single-thread equivalent):
+  - `ops/sec ~= 1e9 / ns_per_op`
+
+## 3) Comparison table template
+
+Use this template in reports:
+
+| Scenario | Benchmark | Count | Benchtime | Median ns/op | p95 ns/op | B/op | allocs/op | Notes |
+|---|---|---:|---|---:|---:|---:|---:|---|
+| Cold init | `BenchmarkCacheInit_ProdLike_Cold` | 3 | `1x` |  |  |  |  | first cache build path |
+| Cold init | `BenchmarkDatasetInit_ProdLike_Cold` | 3 | `1x` |  |  |  |  | first dataset build path |
+| Warm init | `BenchmarkCacheInit_ProdLike_Warm` | 5 | `3x` |  |  |  |  | load existing cache |
+| Warm init | `BenchmarkDatasetInit_ProdLike_Warm` | 5 | `3x` |  |  |  |  | load existing dataset |
+| Warm steady | `BenchmarkColossusHashLight_ProdLike` | 5 | `2s` |  |  |  |  | light hash path |
+| Warm steady | `BenchmarkColossusHashFullWithScratchpad_ProdLike` | 5 | `2s` |  |  |  |  | full hash path |
+| Warm steady | `BenchmarkVerifyHeaderSeal_ProdLike` | 5 | `2s` |  |  |  |  | block header verify |
+| Warm steady | `BenchmarkVerifyKeyHeaderSeal_ProdLike` | 5 | `2s` |  |  |  |  | key header verify |
+| Warm parallel | `BenchmarkColossusHashLight_ProdLike_Parallel` | 5 | `2s` |  |  |  |  | contention/throughput |
+| Warm parallel | `BenchmarkColossusHashFullWithScratchpad_ProdLike_Parallel` | 5 | `2s` |  |  |  |  | contention/throughput |
+| Warm parallel | `BenchmarkVerifyHeaderSeal_ProdLike_Parallel` | 5 | `2s` |  |  |  |  | contention/throughput |
+
+## 4) Notes for stable measurement
+
+- Pin CPU governor and avoid noisy co-tenants.
+- Keep benchmark host memory pressure low, especially for dataset operations.
+- Separate reporting for cold and warm results; do not average them together.

--- a/consensus/colossusx/colossus_bench_test.go
+++ b/consensus/colossusx/colossus_bench_test.go
@@ -1,7 +1,9 @@
 package colossusx
 
 import (
+	"fmt"
 	"math/big"
+	"path/filepath"
 	"runtime"
 	"sync/atomic"
 	"testing"
@@ -15,16 +17,20 @@ const (
 	benchHeaderPool         = 256
 )
 
-func newBenchEngine() *Ethash {
+func newBenchEngineWithDirs(cacheDir, datasetDir string) *Ethash {
 	return New(Config{
-		CacheDir:       "/root/.colossusx",
+		CacheDir:       cacheDir,
 		CachesInMem:    1,
 		CachesOnDisk:   1,
-		DatasetDir:     "/root/.colossusx",
+		DatasetDir:     datasetDir,
 		DatasetsInMem:  1,
 		DatasetsOnDisk: 1,
 		PowMode:        ModeNormal,
 	})
+}
+
+func newBenchEngine() *Ethash {
+	return newBenchEngineWithDirs("/root/.colossusx", "/root/.colossusx")
 }
 
 func benchSealHash() []byte {
@@ -119,6 +125,62 @@ func BenchmarkColossusHashFullWithScratchpad_ProdLike_Parallel(b *testing.B) {
 	runtime.KeepAlive(dataset)
 }
 
+func BenchmarkCacheInit_ProdLike_Cold(b *testing.B) {
+	const number = benchBlockNumber
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		benchDir := filepath.Join(b.TempDir(), fmt.Sprintf("cold-cache-%d", i))
+		engine := newBenchEngineWithDirs(benchDir, benchDir)
+		cache := engine.cache(number)
+		runtime.KeepAlive(cache)
+	}
+}
+
+func BenchmarkCacheInit_ProdLike_Warm(b *testing.B) {
+	const number = benchBlockNumber
+
+	benchDir := b.TempDir()
+	warmEngine := newBenchEngineWithDirs(benchDir, benchDir)
+	_ = warmEngine.cache(number)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		engine := newBenchEngineWithDirs(benchDir, benchDir)
+		cache := engine.cache(number)
+		runtime.KeepAlive(cache)
+	}
+}
+
+func BenchmarkDatasetInit_ProdLike_Cold(b *testing.B) {
+	const number = benchBlockNumber
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		benchDir := filepath.Join(b.TempDir(), fmt.Sprintf("cold-dataset-%d", i))
+		engine := newBenchEngineWithDirs(benchDir, benchDir)
+		dataset := engine.dataset(number)
+		runtime.KeepAlive(dataset)
+	}
+}
+
+func BenchmarkDatasetInit_ProdLike_Warm(b *testing.B) {
+	const number = benchBlockNumber
+
+	benchDir := b.TempDir()
+	warmEngine := newBenchEngineWithDirs(benchDir, benchDir)
+	_ = warmEngine.dataset(number)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		engine := newBenchEngineWithDirs(benchDir, benchDir)
+		dataset := engine.dataset(number)
+		runtime.KeepAlive(dataset)
+	}
+}
+
 func makeValidPowHeaderForBench(b testing.TB, engine *Ethash, number uint64, nonce uint64) *types.Header {
 	b.Helper()
 
@@ -157,6 +219,34 @@ func makeValidPowHeadersForBench(b testing.TB, engine *Ethash, number uint64, co
 	return headers
 }
 
+func makeValidPowKeyHeaderForBench(b testing.TB, engine *Ethash, number uint64, nonce uint64) *types.KeyBlockHeader {
+	b.Helper()
+
+	header := &types.KeyBlockHeader{
+		ParentHash:    common.Hash{},
+		Difficulty:    big.NewInt(1),
+		Number:        new(big.Int).SetUint64(number),
+		Time:          number + 1,
+		BlockType:     0,
+		CommitteeHash: common.Hash{},
+		T_Number:      0,
+	}
+
+	cache := engine.cache(number)
+	size := datasetSize(number)
+	digest, result := colossusHashLight(size, cache.cache, header.SealHash().Bytes(), nonce)
+	runtime.KeepAlive(cache)
+
+	header.Nonce = types.EncodeNonce(nonce)
+	header.MixDigest = common.BytesToHash(digest)
+
+	target := new(big.Int).Div(maxUint256, header.Difficulty)
+	if new(big.Int).SetBytes(result).Cmp(target) > 0 {
+		b.Fatalf("nonce %d is not valid at difficulty=1, unexpected for key-header benchmark setup", nonce)
+	}
+	return header
+}
+
 func BenchmarkVerifyHeaderSeal_ProdLike(b *testing.B) {
 	engine := newBenchEngine()
 	header := makeValidPowHeaderForBench(b, engine, benchBlockNumber, 0)
@@ -188,4 +278,18 @@ func BenchmarkVerifyHeaderSeal_ProdLike_Parallel(b *testing.B) {
 			}
 		}
 	})
+}
+
+func BenchmarkVerifyKeyHeaderSeal_ProdLike(b *testing.B) {
+	engine := newBenchEngine()
+	header := makeValidPowKeyHeaderForBench(b, engine, benchBlockNumber, 0)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if err := engine.VerifyKeyHeaderSeal(header); err != nil {
+			b.Fatal(err)
+		}
+	}
 }


### PR DESCRIPTION
### Motivation

- Provide a reproducible, prod-like benchmark suite for the ColossusX PoW implementation to measure cold vs warm paths and parallel throughput. 
- Document recommended commands and reporting conventions so benchmark runs are consistent and comparable.

### Description

- Add `consensus/colossusx/BENCHMARKING.md` with recommended `go test` commands, reading guidance, a comparison-table template, and stability notes. 
- Extend `consensus/colossusx/colossus_bench_test.go` to support configurable on-disk dirs via `newBenchEngineWithDirs` and keep the existing `newBenchEngine` wrapper. 
- Add cold/warm init benchmarks: `BenchmarkCacheInit_ProdLike_Cold`, `BenchmarkCacheInit_ProdLike_Warm`, `BenchmarkDatasetInit_ProdLike_Cold`, and `BenchmarkDatasetInit_ProdLike_Warm`. 
- Add production-like verification benchmarks including `BenchmarkVerifyKeyHeaderSeal_ProdLike` and helper `makeValidPowKeyHeaderForBench`. 
- Keep existing hash/verify benchmarks and add use of temporary directories for cold runs to avoid cross-run caching.

### Testing

- Ran the benchmark build and executed the benchmark suite with `go test ./consensus/colossusx -run '^$' -bench '^Benchmark.*ProdLike' -benchtime=1x -count=1 -benchmem`, and the benchmarks compiled and executed without panics. 
- Benchmarks were exercised for both cold and warm scenarios using `b.TempDir()`-backed directories and reported allocations and timings as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8cdbae90c8330853b484126638239)