### PR TITLE
network: avoid selecting closed peer connection for sends

### DIFF
--- a/rnet/network/router.go
+++ b/rnet/network/router.go
@@ -380,7 +380,16 @@ func (r *Router) connection(sid ServerIdentityID) Conn {
 	if len(arr) == 0 {
 		return nil
 	}
-	return arr[0]
+
+	// Prefer an active connection. During reconnect races, a closed connection
+	// may temporarily remain in the slice and would otherwise be picked first,
+	// causing repeated "read/write on closed pipe" retries.
+	for _, c := range arr {
+		if c != nil && !c.IsClosed() {
+			return c
+		}
+	}
+	return nil
 }
 
 // registerConnection registers a ServerIdentity for a new connection, mapped with the


### PR DESCRIPTION
### Motivation
- Prevent outbound sends from repeatedly hitting closed connections during reconnect races by avoiding blind selection of the first entry in the connection slice.

### Description
- Update `Router.connection` in `rnet/network/router.go` to iterate the stored connections and return the first non-nil, non-closed connection (`!IsClosed()`), and add a short comment explaining the reconnect-race rationale.

### Testing
- Ran `go test ./rnet/network` which failed due to module layout (`no go.mod` in this environment). 
- Ran `GO111MODULE=off go test ./rnet/network` which failed due to missing GOPATH-resolvable dependencies; no package-level tests could be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb62b1d5d08330a63af792fed5d639)