### PR TITLE
Allow 2-node clusters to make progress and fix NewView threshold logging

### DIFF
--- a/reconfig/hotstuff/hotstuff.go
+++ b/reconfig/hotstuff/hotstuff.go
@@ -231,6 +231,11 @@ func NewHotstuffProtocolManager(a HotStuffApplication, secretKey *bls.SecretKey,
 }
 
 func CalcThreshold(size int) int {
+	if size <= 2 {
+		// Test/dev override: allow 2-node clusters to make progress.
+		// Keep NewView stricter via its local `threshold+1` logic.
+		return 1
+	}
 	return (size + 1) * 2 / 3
 }
 
@@ -689,7 +694,7 @@ func (hsm *HotstuffProtocolManager) handleNewViewMsg(msg *HotstuffMessage) error
 	}
 
 	if len(v.highVoteInfo) < threshold {
-		log.Info("handleNewViewMsg need more voteInfo", "threshold", v.threshold, "current", len(v.highVoteInfo))
+		log.Info("handleNewViewMsg need more voteInfo", "threshold", threshold, "current", len(v.highVoteInfo))
 		return ErrInsufficientQC
 	}
 


### PR DESCRIPTION
### Motivation
- Allow small (test/dev) clusters with 2 or fewer nodes to make progress by adjusting quorum calculation and improve clarity of a NewView log message.

### Description
- Change `CalcThreshold` to return `1` when `size <= 2` and keep the original `(size + 1) * 2 / 3` formula otherwise, with a comment explaining the test/dev override; update `handleNewViewMsg` to log the computed `threshold` variable instead of `v.threshold` when reporting insufficient vote info.

### Testing
- Ran `go test ./...` and a full project build, and the test suite and build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb7c4ea8c88330bd5abca435aaf2c1)