### PR TITLE
network: prefer newest connection when sending

### DIFF
--- a/rnet/network/router.go
+++ b/rnet/network/router.go
@@ -380,7 +380,9 @@ func (r *Router) connection(sid ServerIdentityID) Conn {
 	if len(arr) == 0 {
 		return nil
 	}
-	return arr[0]
+	// Prefer the most recently registered connection. Older entries can be stale
+	// while a reconnect has already succeeded.
+	return arr[len(arr)-1]
 }
 
 // registerConnection registers a ServerIdentity for a new connection, mapped with the


### PR DESCRIPTION
### Motivation
- Repeated `io: read/write on closed pipe` warnings can occur when sends keep selecting a stale, closed connection from the per-peer connection list instead of a freshly reconnected socket. Selecting the most recently registered connection makes retry recovery sticky and reduces churn.

### Description
- Update `Router.connection` in `rnet/network/router.go` to return the most recently registered connection (`arr[len(arr)-1]`) instead of the oldest entry. 
- Add an inline comment explaining that newer entries are preferred because older ones may be stale while a reconnect has already succeeded.

### Testing
- Attempted to run `go test ./rnet/network` but automated tests could not be executed because the repository has no `go.mod` (module not initialized), so `go test` failed to run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbb9e86f0883309a9371e41731ee40)