### PR TITLE
Adjust ethash DAG sizing and keep DAGs memory-resident

### DIFF
--- a/consensus/ethash/algorithm.go
+++ b/consensus/ethash/algorithm.go
@@ -35,8 +35,8 @@ import (
 )
 
 const (
-	datasetInitBytes   = 1 << 30 // Bytes in dataset at genesis
-	datasetGrowthBytes = 1 << 23 // Dataset growth per epoch
+	datasetInitBytes   = 1 << 33 // Bytes in dataset at genesis
+	datasetGrowthBytes = 1 << 28 // Dataset growth per epoch
 	cacheInitBytes     = 1 << 24 // Bytes in cache at genesis
 	cacheGrowthBytes   = 1 << 17 // Cache growth per epoch
 	epochLength        = 30000   // Blocks per epoch
@@ -73,9 +73,6 @@ func calcCacheSize(epoch int) uint64 {
 // block number.
 func datasetSize(block uint64) uint64 {
 	epoch := int(block / epochLength)
-	if epoch < maxEpoch {
-		return datasetSizes[epoch]
-	}
 	return calcDatasetSize(epoch)
 }
 

--- a/eth/config.go
+++ b/eth/config.go
@@ -18,10 +18,6 @@ package eth
 
 import (
 	"math/big"
-	"os"
-	"os/user"
-	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/cypherium/cypher/common"
@@ -54,7 +50,7 @@ var DefaultConfig = Config{
 		CachesOnDisk:     3,
 		CachesLockMmap:   false,
 		DatasetsInMem:    1,
-		DatasetsOnDisk:   2,
+		DatasetsOnDisk:   0,
 		DatasetsLockMmap: false,
 	},
 	NetworkId:               1,
@@ -77,27 +73,6 @@ var DefaultConfig = Config{
 	RPCGasCap:   9000000000000000000,
 	GPO:         DefaultFullGPOConfig,
 	RPCTxFeeCap: 100, // 1 ether
-}
-
-func init() {
-	home := os.Getenv("HOME")
-	if home == "" {
-		if user, err := user.Current(); err == nil {
-			home = user.HomeDir
-		}
-	}
-	if runtime.GOOS == "darwin" {
-		DefaultConfig.Ethash.DatasetDir = filepath.Join(home, "Library", "Ethash")
-	} else if runtime.GOOS == "windows" {
-		localappdata := os.Getenv("LOCALAPPDATA")
-		if localappdata != "" {
-			DefaultConfig.Ethash.DatasetDir = filepath.Join(localappdata, "Ethash")
-		} else {
-			DefaultConfig.Ethash.DatasetDir = filepath.Join(home, "AppData", "Local", "Ethash")
-		}
-	} else {
-		DefaultConfig.Ethash.DatasetDir = filepath.Join(home, ".ethash")
-	}
 }
 
 //go:generate gencodec -type Config -formats toml -out gen_config.go


### PR DESCRIPTION
### Motivation
- Increase the default ethash DAG to a larger initial size and reduce reliance on disk to keep DAGs resident in memory for local/testing setups.
- Ensure the new DAG sizing parameters apply consistently across all epochs by computing sizes from constants rather than a precomputed table.
- Simplify default configuration by avoiding OS-specific dataset directory initialization and favoring in-memory datasets by default.

### Description
- Updated dataset sizing constants in `consensus/ethash/algorithm.go` to start at 8 GiB and grow by 256 MiB per epoch by setting `datasetInitBytes = 1 << 33` and `datasetGrowthBytes = 1 << 28`.
- Modified `datasetSize` in `consensus/ethash/algorithm.go` to always call `calcDatasetSize(epoch)` so the new constants are applied for all epochs instead of returning entries from the `datasetSizes` table.
- Changed default Ethash config in `eth/config.go` to `DatasetsOnDisk: 0` so DAGs are not persisted to disk by default, and removed the OS-specific `init()` that set `DefaultConfig.Ethash.DatasetDir`.
- Files changed: `consensus/ethash/algorithm.go`, `eth/config.go`.

### Testing
- Ran `go test ./consensus/ethash ./eth`, which could not be executed in this environment because the repository is not configured as a Go module and the test runner reported "cannot find main module" (blocked).
- Ran `GO111MODULE=off go test ./consensus/ethash ./eth`, which failed due to unresolved imports and missing dependency resolution in this environment (package resolution errors reported for multiple internal and external packages).
- No package tests passed due to the environment's module/GOPATH constraints; changes compile-time behavior should be validated in a proper Go module or GOPATH checkout with dependencies available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d244a4f29483308ed4abd87e089178)