### PR TITLE
Fix txpool concurrency and seen-map cleanup; skip oversized txs when filling blocks

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -638,8 +638,10 @@ func (pool *TxPool) noteSeen(hash common.Hash) {
 }
 
 func (pool *TxPool) PendingByLane(lane TxLane) (map[common.Address]types.Transactions, error) {
-	pool.mu.RLock()
-	defer pool.mu.RUnlock()
+	// list.Flatten() may update internal caches, so this path requires
+	// exclusive access to avoid races between concurrent callers.
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
 
 	pending := make(map[common.Address]types.Transactions)
 	for addr, list := range pool.pending {
@@ -1493,6 +1495,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 		for _, tx := range forwards {
 			hash := tx.Hash()
 			pool.all.Remove(hash)
+			delete(pool.seen, hash)
 		}
 		log.Trace("Removed old queued transactions", "count", len(forwards))
 		// Drop all transactions that are too costly (low balance or out of gas)
@@ -1500,6 +1503,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 		for _, tx := range drops {
 			hash := tx.Hash()
 			pool.all.Remove(hash)
+			delete(pool.seen, hash)
 		}
 		log.Trace("Removed unpayable queued transactions", "count", len(drops))
 		queuedNofundsMeter.Mark(int64(len(drops)))
@@ -1535,6 +1539,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 			for _, tx := range caps {
 				hash := tx.Hash()
 				pool.all.Remove(hash)
+				delete(pool.seen, hash)
 				log.Trace("Removed cap-exceeding queued transaction", "hash", hash)
 			}
 			queuedRateLimitMeter.Mark(int64(len(caps)))

--- a/reconfig/txblock.go
+++ b/reconfig/txblock.go
@@ -543,8 +543,12 @@ func (env *work) commitTransactions(txes *types.TransactionsByPriceAndNonce, bc 
 		if env.gasTarget > 0 {
 			remainingGas := env.gasTarget - env.header.GasUsed
 			if tx.Gas() > remainingGas {
-				log.Trace("Stopping block assembly at gas target", "gasUsed", env.header.GasUsed, "gasTarget", env.gasTarget, "nextTxGas", tx.Gas(), "blockType", env.blockType)
-				break
+				// This transaction cannot fit into the remaining gas target budget.
+				// Drop this account head from the local proposal view and continue,
+				// so we can still consider other accounts' transactions.
+				log.Trace("Skipping account head above gas target remainder", "gasUsed", env.header.GasUsed, "gasTarget", env.gasTarget, "nextTxGas", tx.Gas(), "blockType", env.blockType)
+				txes.Pop()
+				continue
 			}
 		}
 		if to := tx.To(); to != nil {


### PR DESCRIPTION
### Motivation

- Prevent concurrent access races when calling `list.Flatten()` which may update internal caches. 
- Ensure transactions removed from queues are also removed from the `seen` cache to avoid stale entries.
- Allow block assembly to continue by skipping an account head whose next transaction exceeds the remaining gas target instead of aborting assembly.

### Description

- Change `PendingByLane` to take an exclusive lock with `pool.mu.Lock()` because `list.Flatten()` can mutate internal state and must not run under a read lock. 
- Remove `hash` entries from `pool.seen` whenever a transaction is removed from the queue in `promoteExecutables` (forwards, drops, caps), in addition to removing from `pool.all`. 
- In `commitTransactions`, when a candidate transaction's gas exceeds the remaining per-block gas target, pop that account head with `txes.Pop()` and `continue` to consider other accounts instead of breaking out of block assembly.

### Testing

- Ran unit test suite with `go test ./...` and the tests completed successfully. 
- Ran package-specific tests covering the transaction pool and block assembly paths and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9389249648330b17aacc68a1607dd)