### PR TITLE
reconfig: leader fallback/restore for fixed-mode and timeout adjustments

### DIFF
--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -27,7 +27,7 @@ const (
 	DisableGAS             = false
 	KeyblockPerTxBlocks    = 360
 	MaxTxCountPerBlock     = 1024
-	AckTimeout             = 120 * time.Second
+	AckTimeout             = 20 * time.Second
 	HeatBeatTimeout        = 10 * time.Second
 	PaceMakerTimeout       = 3 * time.Minute
 	KeyBlockTimeout        = 20 * time.Minute

--- a/reconfig/keyblock.go
+++ b/reconfig/keyblock.go
@@ -38,12 +38,15 @@ import (
 type keyService struct {
 	s               serviceI
 	muBestCandidate sync.Mutex
+	muLeaderState   sync.Mutex
 	bestCandidate   *types.Candidate
 	candidatepool   *core.CandidatePool
 	bc              *core.BlockChain
 	kbc             *core.KeyBlockChain
 	engine          consensus.Engine
 	config          *params.ChainConfig
+	primaryLeader   uint
+	activeLeader    uint
 }
 
 func newKeyService(s serviceI, backend *ReconfigBackend, config *params.ChainConfig) *keyService {
@@ -54,7 +57,54 @@ func newKeyService(s serviceI, backend *ReconfigBackend, config *params.ChainCon
 	keyS.kbc = backend.KeyBlockChain()
 	keyS.engine = backend.Engine()
 	keyS.config = config
+	keyS.primaryLeader = 0
+	keyS.activeLeader = 0
 	return keyS
+}
+
+func (keyS *keyService) fixedModeEnabled() bool {
+	return keyS.config != nil && (keyS.config.FixedLeader || keyS.config.FixedCommittee)
+}
+
+func (keyS *keyService) promoteFallbackLeader(current uint) {
+	if !keyS.fixedModeEnabled() {
+		return
+	}
+	mb := bftview.GetCurrentMember()
+	if mb == nil || len(mb.List) == 0 {
+		return
+	}
+
+	keyS.muLeaderState.Lock()
+	defer keyS.muLeaderState.Unlock()
+
+	if keyS.activeLeader >= uint(len(mb.List)) {
+		keyS.activeLeader = keyS.primaryLeader % uint(len(mb.List))
+	}
+	next := current + 1
+	if next >= uint(len(mb.List)) {
+		next = 0
+	}
+	keyS.activeLeader = next
+	log.Warn("fixed-mode leader fallback activated", "primary", keyS.primaryLeader, "active", keyS.activeLeader, "committeeSize", len(mb.List))
+}
+
+func (keyS *keyService) restorePrimaryLeader() {
+	if !keyS.fixedModeEnabled() {
+		return
+	}
+	keyS.muLeaderState.Lock()
+	defer keyS.muLeaderState.Unlock()
+	if keyS.activeLeader != keyS.primaryLeader {
+		log.Info("fixed-mode leader restored", "from", keyS.activeLeader, "to", keyS.primaryLeader)
+	}
+	keyS.activeLeader = keyS.primaryLeader
+}
+
+func (keyS *keyService) getPrimaryLeaderIndex() uint {
+	keyS.muLeaderState.Lock()
+	defer keyS.muLeaderState.Unlock()
+	return keyS.primaryLeader
 }
 
 // Verify keyblock
@@ -283,8 +333,19 @@ func (keyS *keyService) tryProposalChangeCommittee(leaderIndex uint, isDone bool
 }
 
 func (keyS *keyService) getNextLeaderIndex(leaderIndex uint) uint {
-	if keyS.config != nil && (keyS.config.FixedLeader || keyS.config.FixedCommittee) {
-		return 0
+	if keyS.fixedModeEnabled() {
+		mb := bftview.GetCurrentMember()
+		keyS.muLeaderState.Lock()
+		defer keyS.muLeaderState.Unlock()
+		if mb != nil && len(mb.List) > 0 {
+			if keyS.primaryLeader >= uint(len(mb.List)) {
+				keyS.primaryLeader = 0
+			}
+			if keyS.activeLeader >= uint(len(mb.List)) {
+				keyS.activeLeader = keyS.primaryLeader
+			}
+		}
+		return keyS.activeLeader
 	}
 
 	mb := bftview.GetCurrentMember()

--- a/reconfig/paceMaker.go
+++ b/reconfig/paceMaker.go
@@ -155,7 +155,8 @@ func (t *paceMakerTimer) loopTimer() {
 			log.Warn("paceMakerTimer Viewchange AckTimeout")
 			t.setNextLeader(false)
 			t.service.ResetLeaderAckTime()
-		} else if diff > params.PaceMakerTimeout /**time.Duration(retryNumber+1)*/ && bftview.IamMember() >= 0 { //timeout
+		} else if diff > params.PaceMakerTimeout /**time.Duration(retryNumber+1)*/ && bftview.IamMember() >= 0 &&
+			!(t.config != nil && (t.config.FixedLeader || t.config.FixedCommittee)) { //timeout
 			log.Warn("paceMakerTimer Viewchange PaceMakerTimeout Event is coming", "retryNumber", retryNumber)
 			/*
 				switchLen := bftview.GetServerCommitteeLen()/2 + 1

--- a/reconfig/service.go
+++ b/reconfig/service.go
@@ -106,12 +106,12 @@ type Service struct {
 	lastReqCmNumber uint64
 	muCurrentView   sync.Mutex
 
-	replicaView       *bftview.View
-	runningState      int32
-	lastProposeTime   time.Time
-	lastSlowBlockTime time.Time
+	replicaView        *bftview.View
+	runningState       int32
+	lastProposeTime    time.Time
+	lastSlowBlockTime  time.Time
 	tryProposeQueuedAt int64
-	pacetMakerTimer   *paceMakerTimer
+	pacetMakerTimer    *paceMakerTimer
 
 	hotstuffMsgQ *common.Queue
 	feed1        event.Feed
@@ -826,9 +826,16 @@ func (s *Service) setNextLeader(isDone bool) {
 	s.muCurrentView.Lock()
 	defer s.muCurrentView.Unlock()
 
+	if s.keyService.fixedModeEnabled() && s.shouldRestorePrimaryLeader() {
+		s.keyService.restorePrimaryLeader()
+	}
+
 	if isDone {
 		s.currentView.LeaderIndex = s.keyService.getNextLeaderIndex(0)
 	} else {
+		if s.keyService.fixedModeEnabled() {
+			s.keyService.promoteFallbackLeader(s.currentView.LeaderIndex)
+		}
 		s.currentView.LeaderIndex = s.keyService.getNextLeaderIndex(s.currentView.LeaderIndex)
 	}
 	s.currentView.NoDone = !isDone
@@ -836,6 +843,19 @@ func (s *Service) setNextLeader(isDone bool) {
 
 	s.waittingView.TxNumber = s.currentView.TxNumber + 1
 	s.waittingView.KeyNumber = s.currentView.KeyNumber + 1
+}
+
+func (s *Service) shouldRestorePrimaryLeader() bool {
+	mb := bftview.GetCurrentMember()
+	if mb == nil || len(mb.List) == 0 {
+		return false
+	}
+	primary := s.keyService.getPrimaryLeaderIndex()
+	if primary >= uint(len(mb.List)) {
+		return false
+	}
+	ack := s.netService.GetAckTime(mb.List[primary].Address)
+	return time.Since(ack) <= params.AckTimeout
 }
 
 func (s *Service) procBlockDone(block *types.Block) {


### PR DESCRIPTION
### Motivation

- Support stable operation when `FixedLeader`/`FixedCommittee` is enabled by tracking primary/active leaders and allowing fallback and restoration. 
- Reduce the acknowledgement timeout to detect unresponsive nodes faster and avoid long stalls. 
- Prevent PaceMaker-driven view changes while in fixed-mode to avoid unnecessary leader rotations.

### Description

- Change `AckTimeout` from `120 * time.Second` to `20 * time.Second` in `params/protocol_params.go`.
- In `reconfig/keyblock.go` add leader state management on `keyService`: introduce `muLeaderState`, `primaryLeader`, `activeLeader`, and helper methods `fixedModeEnabled`, `promoteFallbackLeader`, `restorePrimaryLeader`, and `getPrimaryLeaderIndex`, and initialize these fields in `newKeyService`.
- Modify `getNextLeaderIndex` to return the active/fixed leader when fixed-mode is enabled and to keep leader state consistent with committee size.
- In `reconfig/service.go` update `setNextLeader` to restore the primary leader when appropriate and to promote a fallback leader on non-done transitions, and add `shouldRestorePrimaryLeader` which checks recent ack times via `netService.GetAckTime` against `params.AckTimeout`.
- In `reconfig/paceMaker.go` avoid firing the regular PaceMaker timeout branch when `FixedLeader`/`FixedCommittee` mode is enabled, and rely on the adjusted `AckTimeout` for faster ack-based view-change detection.
- Keep existing keyblock verification and candidate selection logic intact while wiring the new fixed-mode leader control into the leader selection flow.

### Testing

- Built the project with `go build ./...` which completed successfully.
- Ran unit tests with `go test ./...` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da25651b408330ac0f3f7679a35b0c)