### PR TITLE
Fix fixed-mode fallback leader keyblock proposal

### DIFF
--- a/reconfig/keyblock.go
+++ b/reconfig/keyblock.go
@@ -259,9 +259,6 @@ func (keyS *keyService) verifyKeyBlock(keyblock *types.KeyBlock, bestCandi *type
 // Try to change committee and proposal a new keyblock
 func (keyS *keyService) tryProposalChangeCommittee(leaderIndex uint, isDone bool) (*types.KeyBlock, *bftview.Committee, *types.Candidate, error) {
 	log.Info("tryProposalChangeCommittee", "tx number", keyS.bc.CurrentBlockN(), "isDone", isDone, "leaderIndex", leaderIndex)
-	if keyS.config != nil && (keyS.config.FixedLeader || keyS.config.FixedCommittee) {
-		leaderIndex = 0
-	}
 	curKeyBlock := keyS.kbc.CurrentBlock()
 	curKNumber := curKeyBlock.Number()
 	curKHash := curKeyBlock.Hash()


### PR DESCRIPTION
### Motivation
- In fixed-leader/fixed-committee mode the pacemaker promotes a fallback leader on timeouts, but the keyblock proposal path was forcibly resetting the leader index to 0 causing proposals to target the primary leader and stalling progress when the primary is down.

### Description
- Removed the forced `leaderIndex = 0` overwrite in `keyService.tryProposalChangeCommittee` so the supplied/fallback leader index is respected when constructing committee-change keyblocks.
- The change is narrowly scoped to `reconfig/keyblock.go` and preserves the existing behavior of disabling POW candidates in fixed mode (`best = nil`).

### Testing
- Ran `go test ./reconfig/...` which failed due to the container not having a Go module root (environment dependency issue).
- Ran `go test ./...` which failed for the same module/GOPATH reasons. 
- Ran `make cypher` which failed due to unresolved Go module dependencies. 
- Ran `GO111MODULE=off go test ./reconfig/...` which failed due to missing GOPATH-placed dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa820914083308a52492183c8d9be)