### PR TITLE
Enable TxPool new-tx event loop and notify view on incoming transactions

### DIFF
--- a/reconfig/paceMaker.go
+++ b/reconfig/paceMaker.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/cypherium/cypher/core"
 	"github.com/cypherium/cypher/core/types"
-	//	"github.com/cypherium/cypher/event"
+	"github.com/cypherium/cypher/event"
 	"github.com/cypherium/cypher/log"
 	"github.com/cypherium/cypher/params"
 	"github.com/cypherium/cypher/reconfig/bftview"
@@ -45,8 +45,8 @@ type paceMakerTimer struct {
 	kbc           *core.KeyBlockChain
 	mu            sync.Mutex
 
-	//	txsCh  chan core.NewTxsEvent
-	//	txsSub event.Subscription
+	txsCh  chan core.NewTxsEvent
+	txsSub event.Subscription
 }
 
 func newPaceMakerTimer(config *params.ChainConfig, s serviceI, backend *ReconfigBackend) *paceMakerTimer {
@@ -62,9 +62,9 @@ func newPaceMakerTimer(config *params.ChainConfig, s serviceI, backend *Reconfig
 		config:        config,
 	}
 
-	//	t.txsCh = make(chan core.NewTxsEvent, 128)
-	//	t.txsSub = backend.TxPool().SubscribeNewTxsEvent(t.txsCh)
-	//	go t.txsEventLoop()
+	t.txsCh = make(chan core.NewTxsEvent, 128)
+	t.txsSub = backend.TxPool().SubscribeNewTxsEvent(t.txsCh)
+	go t.txsEventLoop()
 
 	go t.loopTimer()
 	return t
@@ -225,7 +225,6 @@ func (t *paceMakerTimer) procBlockDone(curBlock *types.Block, curKeyBlock *types
 
 }
 
-/*
 func (t *paceMakerTimer) txsEventLoop() {
 	for {
 		select {
@@ -240,6 +239,9 @@ func (t *paceMakerTimer) txsEventLoop() {
 				t.startTime = time.Now()
 			}
 			t.mu.Unlock()
+			if bftview.IamMember() >= 0 {
+				t.service.sendNewViewMsg(t.service.GetCurrentView().TxNumber)
+			}
 
 		case <-t.txsSub.Err():
 			log.Info("txsEventLoop stopped")
@@ -247,4 +249,3 @@ func (t *paceMakerTimer) txsEventLoop() {
 		}
 	}
 }
-*/


### PR DESCRIPTION
### Motivation

- Re-enable the transaction-driven pacing logic so the pacemaker reacts to incoming transactions and can trigger view updates promptly.
- Restore the `txsEventLoop` subscription to `TxPool` new-tx events which was previously commented out, improving reactivity and throughput for members.

### Description

- Reintroduced the `event` import and the `txsCh` and `txsSub` fields on `paceMakerTimer` to track `core.NewTxsEvent` subscriptions. 
- Subscribed to new-tx events via `backend.TxPool().SubscribeNewTxsEvent(t.txsCh)` and started the event loop with `go t.txsEventLoop()` in `newPaceMakerTimer`. 
- Uncommented `txsEventLoop` implementation and added logic to call `t.service.sendNewViewMsg(t.service.GetCurrentView().TxNumber)` when `bftview.IamMember() >= 0` upon receiving new transactions.

### Testing

- Built the codebase with `go build ./...` which completed successfully. 
- Ran unit tests with `go test ./...` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf25f9ac4833091f7240ecf5a1fbc)