### PR TITLE
Migrate miner and keystore from ed25519 types to generic ECDSA/BLS byte handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Start the node:
 
 ## console command (mining)
 ```powershell
-personal.newAccountEd25519("your password")
+personal.newAccount("your password")
 ```
 ```powershell
-miner.start(1, "Ed25519 address", "your password")
+miner.start(1, "ECDSA address", "your password")
 ```
 
 

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -534,20 +534,27 @@ func zeroKey(k *ecdsa.PrivateKey) {
 	}
 }
 
-//--ed25519--------------------------------------------------------------------------
+//--ECDSA--------------------------------------------------------------------------
 
 func (ks *KeyStore) GetKeyPair(account accounts.Account, passphrase string) ([]byte, []byte, error) {
 	_, key, err := ks.getDecryptedKey(account, passphrase)
 	if err != nil {
 		return nil, nil, err
 	}
-	if key.PrivateKey25519 == nil {
-		return nil, nil, errors.New("the account can not decrypted by ed25519")
+	if key.PrivateKey == nil {
+		return nil, nil, errors.New("the account can not decrypted by ecdsa")
 
 	}
-	defer zeroKey25519(key.PrivateKey25519)
+	defer zeroKey(key.PrivateKey)
 
-	pubKey, priKey, err := crypto.EDDSAToBLS(key.PrivateKey25519)
+	privateKey := crypto.FromECDSA(key.PrivateKey)
+	defer func() {
+		for i := range privateKey {
+			privateKey[i] = 0
+		}
+	}()
+
+	pubKey, priKey, err := crypto.EDDSAToBLS(privateKey)
 	return pubKey, priKey, err
 }
 

--- a/eth/api.go
+++ b/eth/api.go
@@ -42,7 +42,6 @@ import (
 	"github.com/cypherium/cypher/trie"
 	//"github.com/cypherium/cypher/params"
 	"github.com/cypherium/cypher/reconfig/bftview"
-	"golang.org/x/crypto/ed25519"
 )
 
 // PublicEthereumAPI provides an API to access Ethereum full node-related
@@ -152,10 +151,10 @@ func (api *PrivateMinerAPI) Start(threads *int) error {
 */
 func (api *PrivateMinerAPI) Start(threads *int, addr common.Address, password string) error {
 	var (
-		err    error
-		eb     common.Address
-		prvKey ed25519.PrivateKey
-		pubKey ed25519.PublicKey
+		err          error
+		eb           common.Address
+		blsPrivKey   []byte
+		blsPublicKey []byte
 	)
 
 	if api.e.IsMining() {
@@ -173,21 +172,21 @@ func (api *PrivateMinerAPI) Start(threads *int, addr common.Address, password st
 		for _, account := range wallet.Accounts() {
 			if account.Address == eb {
 				//wallet.GetPubKey(account, passwd)
-				pubKey, prvKey, err = wallet.GetKeyPair(account, password)
+				blsPublicKey, blsPrivKey, err = wallet.GetKeyPair(account, password)
 				if err != nil {
-					log.Error("Cannot start reconfig without public key of coinbase", "err", err)
-					return fmt.Errorf("Coinbase missing public key: %v", err)
+					log.Error("Cannot start reconfig with non-ECDSA coinbase account", "err", err)
+					return fmt.Errorf("coinbase must be an ECDSA account: %v", err)
 				}
-				server.Public = common.HexString(pubKey)
-				server.Private = common.HexString(prvKey)
+				server.Public = common.HexString(blsPublicKey)
+				server.Private = common.HexString(blsPrivKey)
 				//log.Info("miner.start", "addr", eb, "pub", server.Public)
 			}
 		}
 	}
 
-	if pubKey == nil || prvKey == nil {
-		log.Error("Cannot start reconfig without correct public key")
-		return errors.New("missing public key")
+	if blsPublicKey == nil || blsPrivKey == nil {
+		log.Error("Cannot start reconfig without BLS key pair")
+		return errors.New("missing BLS key pair (ECDSA account required)")
 	}
 	log.Warn("pubKey", "pubKey", server.Public) //, "prvKey", server.Private)
 	log.Warn("exip", "ip", api.e.ExtIP(), "port", api.e.config.RnetPort)
@@ -209,7 +208,7 @@ func (api *PrivateMinerAPI) Start(threads *int, addr common.Address, password st
 	//	log.Info("Updated mining threads", "threads", *threads)
 	//	th.SetThreads(*threads)
 	//}
-	return api.e.StartMining(true, eb, pubKey)
+	return api.e.StartMining(true, eb, blsPublicKey)
 }
 
 // Stop terminates the miner, both at the consensus engine level as well as at

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -50,7 +50,6 @@ import (
 	"github.com/cypherium/cypher/log"
 	"github.com/cypherium/cypher/miner"
 	"github.com/cypherium/cypher/reconfig/bftview"
-	"golang.org/x/crypto/ed25519"
 
 	"github.com/cypherium/cypher/node"
 	"github.com/cypherium/cypher/p2p"
@@ -515,7 +514,7 @@ func (s *Ethereum) StopMining() {
 }
 */
 func (s *Ethereum) ServiceIsRunning() bool { return s.reconfig.ServiceIsRunning() }
-func (s *Ethereum) StartMining(local bool, eb common.Address, pubKey ed25519.PublicKey) error {
+func (s *Ethereum) StartMining(local bool, eb common.Address, pubKey []byte) error {
 	// If the miner was not running, initialize it
 	if !s.IsMining() {
 		s.lock.RLock()
@@ -551,7 +550,7 @@ func (s *Ethereum) ArchiveMode() bool                                { return s.
 func (s *Ethereum) BloomIndexer() *core.ChainIndexer                 { return s.bloomIndexer }
 func (s *Ethereum) CandidatePool() *core.CandidatePool               { return s.candidatePool }
 func (s *Ethereum) ExtIP() net.IP                                    { return s.extIP }
-func (s *Ethereum) PublicKey() ed25519.PublicKey                     { return s.miner.GetPubKey() }
+func (s *Ethereum) PublicKey() []byte                                { return s.miner.GetPubKey() }
 func (s *Ethereum) GetCalcGasLimit() func(block *types.Block) uint64 { return s.CalcGasLimit }
 
 // Protocols returns all the currently configured

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -301,13 +301,14 @@ func (s *PrivateAccountAPI) NewAccount(password string) (common.Address, error) 
 	return common.Address{}, err
 }
 
-// NewAccountEd25519 will create a new account and returns the address for the new account.
+// NewAccountEd25519 is kept for backward compatibility and now creates an ECDSA account.
 func (s *PrivateAccountAPI) NewAccountEd25519(password string) (common.Address, error) {
 	ks, err := fetchKeystore(s.am)
 	if err != nil {
 		return common.Address{}, err
 	}
-	acc, err := ks.NewAccount25519(password)
+	log.Warn("personal_newAccountEd25519 is deprecated; creating an ECDSA account instead")
+	acc, err := ks.NewAccount(password)
 	if err == nil {
 		log.Info("Your new key was generated", "address", acc.Address)
 		log.Warn("Please backup your key file!", "path", acc.URL.Path)

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -22,7 +22,7 @@ var Modules = map[string]string{
 	"admin":          AdminJs,
 	"chequebook":     ChequebookJs,
 	"clique":         CliqueJs,
-	"colossusX":         colossusXJs,
+	"colossusX":      colossusXJs,
 	"debug":          DebugJs,
 	"eth":            EthJs,
 	"miner":          MinerJs,
@@ -735,8 +735,13 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
+			name: 'newAccount',
+			call: 'personal_newAccount',
+			params: 1
+		}),
+		new web3._extend.Method({
 			name: 'newAccountEd25519',
-			call: 'personal_newAccountEd25519',
+			call: 'personal_newAccount',
 			params: 1
 		}),
 		new web3._extend.Method({

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -4,8 +4,6 @@ import (
 	"math/big"
 	"time"
 
-	"golang.org/x/crypto/ed25519"
-
 	"net"
 
 	"github.com/cypherium/cypher/accounts"
@@ -48,7 +46,7 @@ type Config struct {
 type Miner struct {
 	mux         *event.TypeMux
 	worker      *worker
-	pubKey      ed25519.PublicKey
+	pubKey      []byte
 	coinBase    common.Address
 	eth         Backend
 	engine      consensus.Engine
@@ -70,7 +68,7 @@ func New(eth Backend, config *params.ChainConfig, mux *event.TypeMux, engine con
 	return miner
 }
 
-func (self *Miner) Start(pubKey ed25519.PublicKey, eb common.Address) {
+func (self *Miner) Start(pubKey []byte, eb common.Address) {
 
 	self.SetPubKey(pubKey)
 	self.SetCoinbase(eb)
@@ -114,11 +112,11 @@ func (self *Miner) HashRate() uint64 {
 	return 0
 }
 
-func (self *Miner) GetPubKey() ed25519.PublicKey {
+func (self *Miner) GetPubKey() []byte {
 	return self.pubKey
 }
 
-func (self *Miner) SetPubKey(pubKey ed25519.PublicKey) {
+func (self *Miner) SetPubKey(pubKey []byte) {
 	self.pubKey = pubKey
 	self.worker.SetPubKey(pubKey)
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -8,8 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/crypto/ed25519"
-
 	"github.com/cypherium/cypher/common"
 	"github.com/cypherium/cypher/core"
 	"github.com/cypherium/cypher/core/types"
@@ -75,7 +73,7 @@ type worker struct {
 	chain   *core.KeyBlockChain // todo: should be the key block
 	chainDb ethdb.Database
 
-	pubKey    ed25519.PublicKey
+	pubKey    []byte
 	coinBase  common.Address
 	currentMu sync.Mutex
 	current   *Work
@@ -322,7 +320,7 @@ func (self *worker) commitNewWork() {
 	}
 }
 
-func (self *worker) SetPubKey(pubKey ed25519.PublicKey) {
+func (self *worker) SetPubKey(pubKey []byte) {
 	self.pubKey = pubKey
 }
 


### PR DESCRIPTION
### Motivation
- Consolidate account handling to use ECDSA-based keystore operations and byte-oriented BLS keys for mining and reconfiguration instead of concrete `ed25519` types.
- Update public APIs and web3 shims to remain backward compatible with callers while steering users to the canonical `personal_newAccount` flow.

### Description
- Replaced `ed25519` typed public/private keys with generic `[]byte` across `miner`, `worker`, `eth`, and related packages, including changing signatures for `StartMining`, `GetPubKey`, `SetPubKey`, and `PublicKey` to accept/return `[]byte`.
- Modified keystore logic to obtain raw ECDSA private key bytes via `crypto.FromECDSA` and adjusted `GetKeyPair` to error when no ECDSA private key is present and to zero sensitive bytes after use.
- Updated RPC/account APIs to deprecate `personal_newAccountEd25519` (keeping compatibility) and route it to create ECDSA accounts while logging a deprecation warning, and updated web3 extension mappings to call `personal_newAccount` for the legacy method name.
- Adjusted user-facing messages and the README to reflect the new `personal.newAccount` usage and miner start messaging for ECDSA addresses, and updated miner-related server fields to use hex strings of the BLS byte pairs.

### Testing
- Ran `go build ./...` against the modified codebase and the project compiled successfully.
- No new automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22ed3aebc8330a5daec1a685b09af)