### PR TITLE
Fix fixed-mode keyblock trigger being reset by tx blocks

### DIFF
--- a/reconfig/service.go
+++ b/reconfig/service.go
@@ -681,9 +681,14 @@ func (s *Service) updateCurrentView(curBlock *types.Block, curKeyBlock *types.Ke
 	s.currentView.KeyHash = curKeyBlock.Hash()
 	s.currentView.CommitteeHash = curKeyBlock.CommitteeHash()
 
+	fixedMode := s.keyService.config != nil && (s.keyService.config.FixedLeader || s.keyService.config.FixedCommittee)
 	if fromKeyBlock || curBlock.NumberU64() > curKeyBlock.T_Number() {
 		s.currentView.LeaderIndex = 0
-		s.currentView.NoDone = true
+		// In fixed mode, keep a pending keyblock trigger (NoDone=false) across tx-block updates
+		// so the proposer can still emit a key block even while tx blocks keep arriving.
+		if !(fixedMode && !fromKeyBlock && !s.currentView.NoDone) {
+			s.currentView.NoDone = true
+		}
 	}
 	log.Debug("updateCurrentView", "TxNumber", s.currentView.TxNumber, "KeyNumber", s.currentView.KeyNumber, "LeaderIndex", s.currentView.LeaderIndex, "NoDone", s.currentView.NoDone)
 	if fromKeyBlock || (s.currentView.TxNumber >= s.waittingView.TxNumber && s.currentView.KeyNumber >= s.waittingView.KeyNumber) || curBlock.BlockType() == types.Key_Block {


### PR DESCRIPTION
### Motivation
- In fixed mode the pacemaker may set a pending keyblock trigger (`NoDone=false`) (e.g. on the 10‑minute timer), but subsequent tx‑block updates in `updateCurrentView` unconditionally set `NoDone=true`, which prevented fixed‑mode keyblock proposals from occurring when the node started mining tx blocks. 
- This caused observed behavior where keyblocks were generated in fixed intervals until local mining began, after which tx activity repeatedly cleared the pending keyblock state and stopped the periodic keyblock generation.

### Description
- Add a `fixedMode` detection and change the `updateCurrentView` logic so that when `fixedMode` is enabled and a pending keyblock trigger is already set (`NoDone==false`) a tx‑block update does not flip `NoDone` back to `true` (change in `reconfig/service.go`).
- The modification preserves the pending keyblock trigger across tx‑block arrivals so fixed‑mode keyblock proposals stay eligible while tx blocks continue to be mined.
- The change is limited to `updateCurrentView` and uses `s.keyService.config.FixedLeader`/`FixedCommittee` to detect fixed mode.

### Testing
- Attempted `go test ./reconfig/...` but the container environment could not resolve module dependencies so the tests did not run and the command failed due to Go module/workspace configuration. 
- Attempted `GO111MODULE=off go test ./reconfig/...` but package resolution failed because the repository is not set up as a GOPATH workspace and required packages could not be found. 
- No automated unit tests were executed successfully in this environment; the change is localized and compiled-formatting was applied with `gofmt` before committing locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2ac75ba988330991c7c6e40ea31f6)