### PR TITLE
reconfig: preserve fixed-mode keyblock trigger across tx updates and add debug log

### DIFF
--- a/reconfig/service.go
+++ b/reconfig/service.go
@@ -686,8 +686,11 @@ func (s *Service) updateCurrentView(curBlock *types.Block, curKeyBlock *types.Ke
 		s.currentView.LeaderIndex = 0
 		// In fixed mode, keep a pending keyblock trigger (NoDone=false) across tx-block updates
 		// so the proposer can still emit a key block even while tx blocks keep arriving.
-		if !(fixedMode && !fromKeyBlock && !s.currentView.NoDone) {
+		preservePendingKeyBlock := fixedMode && !fromKeyBlock && !s.currentView.NoDone
+		if !preservePendingKeyBlock {
 			s.currentView.NoDone = true
+		} else {
+			log.Debug("updateCurrentView preserve fixed-mode keyblock trigger", "txNumber", curBlock.NumberU64(), "keyNumber", curKeyBlock.NumberU64())
 		}
 	}
 	log.Debug("updateCurrentView", "TxNumber", s.currentView.TxNumber, "KeyNumber", s.currentView.KeyNumber, "LeaderIndex", s.currentView.LeaderIndex, "NoDone", s.currentView.NoDone)


### PR DESCRIPTION
### Motivation
- In fixed mode the pace-maker timer triggers periodic keyblock proposals by setting `NoDone=false`, but `Service.updateCurrentView` could immediately overwrite `NoDone` to `true` on TX-block updates and cancel the pending keyblock; this change makes the preservation explicit and observable.

### Description
- Add a `preservePendingKeyBlock` flag in `Service.updateCurrentView` and only reset `s.currentView.NoDone` when the pending trigger should not be preserved in fixed mode.
- Emit a debug log `updateCurrentView preserve fixed-mode keyblock trigger` when a pending fixed-mode keyblock trigger is intentionally preserved; the change is applied in `reconfig/service.go`.

### Testing
- Attempted to run `go test ./reconfig/...` in this environment, but the run failed with `directory prefix reconfig does not contain main module` due to the repository/module layout, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2bc6be4ec8330ae82b5768f04a50f)