### PR TITLE
Use chain-config EIP158 flag when computing IntermediateRoot for proposed blocks

### DIFF
--- a/reconfig/txblock.go
+++ b/reconfig/txblock.go
@@ -82,7 +82,7 @@ func (txS *txService) tryProposalNewKeyBlock(keyblock *types.KeyBlock) ([]byte, 
 	header := work.header
 	// commit state root after all state transitions.
 	colossusX.AccumulateRewards(txS.bc.Config(), work.publicState, header, nil)
-	header.Root = work.publicState.IntermediateRoot(false)
+	header.Root = work.publicState.IntermediateRoot(txS.bc.Config().IsEIP158(header.Number))
 
 	header.BlockType = types.Key_Block
 	header.Difficulty = keyblock.Difficulty()
@@ -120,7 +120,7 @@ func (txS *txService) tryProposalNewBlock(blockType uint8) ([]byte, error) {
 
 	// commit state root after all state transitions.
 	colossusX.AccumulateRewards(txS.bc.Config(), work.publicState, header, nil)
-	header.Root = work.publicState.IntermediateRoot(false)
+	header.Root = work.publicState.IntermediateRoot(txS.bc.Config().IsEIP158(header.Number))
 	header.KeyHash = txS.kbc.CurrentBlock().Hash()
 
 	// update block hash since it is now available, but was not when the


### PR DESCRIPTION
### Motivation
- Ensure the state trie root is computed with the correct EIP158 semantics for the block number being proposed so the header root matches chain consensus after EIP158 activation.

### Description
- Replace the hard-coded `false` argument to `publicState.IntermediateRoot` with `txS.bc.Config().IsEIP158(header.Number)` in both `tryProposalNewKeyBlock` and `tryProposalNewBlock` so the root computation honors the chain configuration.

### Testing
- Ran `go test ./...` on the repository and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2d4fde7c8833086b469f60187cb65)