### PR TITLE
reconfig: harden keyblock verification for missing candidate and empty OutAddress

### DIFF
--- a/reconfig/keyblock.go
+++ b/reconfig/keyblock.go
@@ -75,6 +75,9 @@ func (keyS *keyService) verifyKeyBlock(keyblock *types.KeyBlock, bestCandi *type
 
 	var newNode *common.Cnode
 	if keyblock.HasNewNode() {
+		if bestCandi == nil {
+			return fmt.Errorf("keyblock verify failed, missing best candidate for pow reconfig block")
+		}
 		newNode = &common.Cnode{
 			Address:  net.IP(bestCandi.IP).String() + ":" + strconv.Itoa(bestCandi.Port),
 			CoinBase: keyblock.InAddress(),
@@ -190,6 +193,9 @@ func (keyS *keyService) verifyKeyBlock(keyblock *types.KeyBlock, bestCandi *type
 			return fmt.Errorf("keyblock verify failed, PowReconfig or PacePowReconfig should has outer")
 		}
 		outAddress := keyblock.OutAddress(0)
+		if outAddress == "" {
+			return fmt.Errorf("keyblock verify failed, outer address is empty")
+		}
 		isBadAddress := false
 		if outAddress[0] == '*' {
 			outAddress = outAddress[1:]


### PR DESCRIPTION
### Motivation
- Prevent panics or out-of-range accesses during keyblock verification when PoW-style keyblocks advertise new nodes but the accompanying candidate payload (`extra`) is missing or malformed. 
- Ensure malformed `OutAddress` fields cannot trigger indexing errors and cause the node to crash or halt network progress.

### Description
- Add a defensive nil check in `verifyKeyBlock` so when `keyblock.HasNewNode()` is true and the provided `bestCandi` is `nil`, the function returns a validation error instead of dereferencing a nil candidate. 
- Add a guard to check that `outAddress` is not empty before accessing `outAddress[0]` in the PoW/PacePoW branch, returning a validation error if it is empty. 
- These changes convert potential panics/out-of-range errors into regular verification failures with clear error messages and do not alter the existing verification logic beyond input validation. 

### Testing
- Ran `go test ./reconfig/...` from repository root, which failed in this environment with module path errors (`directory prefix reconfig does not contain main module`), so package tests could not be executed here. 
- Ran `GO111MODULE=off go test ./reconfig/...`, which failed due to unresolved GOPATH imports in the sandbox (`cannot find package "github.com/cypherium/cypher/..."`), so no package tests passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e30489c90c8330a4bd2eab590899b5)