### PR TITLE
reconfig: honor EIP158 when committing proposed tx block state

### DIFF
--- a/reconfig/txblock.go
+++ b/reconfig/txblock.go
@@ -134,7 +134,7 @@ func (txS *txService) tryProposalNewBlock(blockType uint8) ([]byte, error) {
 
 	log.Info("Generated next block", "block num", block.Number(), "num txes", txCount)
 
-	if err := txS.bc.CommitBlockWithState(false, work.publicState); err != nil {
+	if err := txS.bc.CommitBlockWithState(txS.bc.Config().IsEIP158(header.Number), work.publicState); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
### Motivation
- A mismatch between the block header `Root` (computed with `IsEIP158(header.Number)`) and the pre-insert state commit semantics (`CommitBlockWithState(false, ...)`) can produce divergent trie roots and trigger `invalid merkle root` errors during block insertion.

### Description
- Change `reconfig/txblock.go` to call `CommitBlockWithState(txS.bc.Config().IsEIP158(header.Number), work.publicState)` instead of passing `false`, so the trie commit behavior matches the header's `IntermediateRoot` calculation.

### Testing
- Ran `go test ./reconfig/...` which failed in this environment due to module/import resolution and not the code change. 
- Ran `GO111MODULE=off go test ./reconfig/...` which also failed for the same repository/module path resolution reasons.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3159cb17c8330b3e96d8642550b8b)