### PR TITLE
Verify txBlock against parent state and remove leader-skip shortcut

### DIFF
--- a/reconfig/txblock.go
+++ b/reconfig/txblock.go
@@ -162,9 +162,6 @@ func (txS *txService) verifyTxBlock(txblock *types.Block) error {
 		retErr = fmt.Errorf("keyhash:%x does not match current keyhash: %x", header.KeyHash, kbc.CurrentBlock().Hash())
 		return retErr
 	}
-	if bftview.IamLeader(txS.s.GetCurrentView().LeaderIndex) {
-		return nil
-	}
 	err := bc.Engine().VerifyHeader(bc, header, false)
 	if err != nil {
 		retErr = fmt.Errorf("invalid header, error:%s", err.Error())
@@ -175,23 +172,26 @@ func (txS *txService) verifyTxBlock(txblock *types.Block) error {
 		retErr = fmt.Errorf("invalid body, error:%s", err.Error())
 		return retErr
 	}
-	/*
-		statedb, _, err := bc.State()
-		if err != nil {
-			retErr = fmt.Errorf("cannot get statedb, error:%s", err.Error())
-			return retErr
-		}
-		receipts, _, usedGas, err := bc.Processor.Process(txblock, statedb, vm.Config{})
-		if err != nil {
-			retErr = fmt.Errorf("cannot get receipts, error:%s", err.Error())
-			return retErr
-		}
-		err = bc.Validator.ValidateState(txblock, bc.GetBlockByHash(txblock.ParentHash()), statedb, receipts, usedGas)
-		if err != nil {
-			retErr = fmt.Errorf("Invalid state, error:%s", err.Error())
-			return retErr
-		}
-	*/
+	parent := bc.GetBlockByHash(txblock.ParentHash())
+	if parent == nil {
+		retErr = fmt.Errorf("cannot get parent block for state validation, parentHash:%x", txblock.ParentHash())
+		return retErr
+	}
+	statedb, err := bc.StateAt(parent.Root())
+	if err != nil {
+		retErr = fmt.Errorf("cannot get parent statedb, error:%s", err.Error())
+		return retErr
+	}
+	receipts, _, usedGas, err := bc.Processor().Process(txblock, statedb, vm.Config{})
+	if err != nil {
+		retErr = fmt.Errorf("cannot process txblock for state validation, error:%s", err.Error())
+		return retErr
+	}
+	err = bc.Validator().ValidateState(txblock, statedb, receipts, usedGas)
+	if err != nil {
+		retErr = fmt.Errorf("invalid state, error:%s", err.Error())
+		return retErr
+	}
 	return nil
 }
 
@@ -214,7 +214,7 @@ func (txS *txService) decideNewBlock(block *types.Block, sig []byte, mask []byte
 	return nil
 }
 
-//-----------------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------------
 func (txS *txService) procBlockDone(newBlock *types.Block) {
 	log.Info("chainBlockEvent...", "number", newBlock.NumberU64())
 	txS.txPool.RemoveBatch(newBlock.Transactions())


### PR DESCRIPTION
### Motivation
- Ensure txBlock verification performs full state validation using the parent block's state and that leaders do not skip validation.

### Description
- Removed the early return that skipped verification for leader nodes so all nodes validate txBlocks.
- Look up the parent block with `bc.GetBlockByHash` and return an error if the parent is missing before attempting state validation.
- Retrieve the parent state with `bc.StateAt(parent.Root())` instead of calling `bc.State()` and then process the block via `bc.Processor().Process(...)` to obtain receipts and gas used.
- Validate the resulting state using `bc.Validator().ValidateState(txblock, statedb, receipts, usedGas)` and improved error messages for each failure case.

### Testing
- Built the project with `go build` and executed unit tests with `go test ./...`, and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e31e391d288330a543fc4c6b02a132)