### PR TITLE
Enforce keyblock TypeCheck rules and add fixed-mode paceMaker throttling

### DIFF
--- a/core/types/keyblock.go
+++ b/core/types/keyblock.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cypherium/cypher/common"
 	"github.com/cypherium/cypher/log"
+	"github.com/cypherium/cypher/params"
 	"github.com/cypherium/cypher/rlp"
 )
 
@@ -244,15 +245,22 @@ func (b *KeyBlock) HasNewNode() bool {
 	return b.header.BlockType == PowReconfig || b.header.BlockType == PacePowReconfig
 }
 func (b *KeyBlock) TypeCheck(last_T_Number uint64) bool {
-	/*
-		keyType := b.BlockType()
-		if keyType == PowReconfig && (b.T_Number()-last_T_Number)%params.KeyblockPerTxBlocks != 0 {
-			return false
-		} else if keyType == TimeReconfig && (b.T_Number()-last_T_Number)%params.GapTxBlocks != 0 {
-			return false
-		}
-	*/
-	return true
+	if b.T_Number() <= last_T_Number {
+		return false
+	}
+	delta := b.T_Number() - last_T_Number
+	keyType := b.BlockType()
+
+	if keyType == PowReconfig {
+		return delta%params.KeyblockPerTxBlocks == 0
+	} else if keyType == PacePowReconfig {
+		return delta%params.KeyblockPerTxBlocks != 0
+	} else if keyType == TimeReconfig {
+		return delta%params.GapTxBlocks == 0
+	} else if keyType == PaceReconfig {
+		return delta%params.GapTxBlocks != 0
+	}
+	return false
 }
 
 // Body returns the non-header content of the block.

--- a/reconfig/keyblock.go
+++ b/reconfig/keyblock.go
@@ -132,6 +132,9 @@ func (keyS *keyService) verifyKeyBlock(keyblock *types.KeyBlock, bestCandi *type
 		if hasFixedPowCarrier && bestCandi == nil {
 			return fmt.Errorf("keyblock verify failed, fixed mode requires best candidate when pow carrier fields are set")
 		}
+		if !hasFixedPowCarrier && bestCandi != nil {
+			return fmt.Errorf("keyblock verify failed, fixed mode best candidate provided but pow carrier fields are empty")
+		}
 	}
 	if fixedMode && bestCandi != nil {
 		bestCandi.KeyCandidate.BlockType = keyType
@@ -351,7 +354,7 @@ func (keyS *keyService) getNextLeaderIndex(leaderIndex uint) uint {
 
 	for loopi := 0; loopi < 3; loopi++ {
 		if curblock.BlockType() == types.PaceReconfig || curblock.BlockType() == types.PacePowReconfig {
-			curblock := kbc.GetBlockByHash(curblock.ParentHash())
+			curblock = kbc.GetBlockByHash(curblock.ParentHash())
 			if curblock != nil {
 				badNodes[curblock.LeaderAddress()] = true
 			}

--- a/reconfig/paceMaker.go
+++ b/reconfig/paceMaker.go
@@ -31,6 +31,7 @@ import (
 
 var maxPaceMakerTime time.Time
 var fixedModeKeyBlockInterval = 10 * time.Minute
+var fixedModeTriggerThrottle = 2 * time.Second
 
 type paceMakerTimer struct {
 	startTime     time.Time
@@ -55,6 +56,7 @@ func newPaceMakerTimer(config *params.ChainConfig, s serviceI, backend *Reconfig
 		service:       s,
 		txPool:        backend.TxPool(),
 		candidatepool: backend.CandidatePool(),
+		kbc:           backend.KeyBlockChain(),
 		startTime:     maxPaceMakerTime,
 		lastKeyTime:   time.Now(),
 		beStop:        true,
@@ -135,16 +137,11 @@ func (t *paceMakerTimer) loopTimer() {
 
 		now := time.Now()
 		if t.config != nil && (t.config.FixedLeader || t.config.FixedCommittee) && bftview.IamMember() >= 0 {
-			t.mu.Lock()
-			lastKeyTime := t.lastKeyTime
-			if now.Sub(lastKeyTime) >= fixedModeKeyBlockInterval {
-				t.lastKeyTime = now
-				t.mu.Unlock()
-				log.Warn("paceMakerTimer fixed mode keyblock trigger", "elapsed", now.Sub(lastKeyTime))
+			if chainElapsed, localElapsed, shouldTrigger := t.shouldTriggerFixedModeKeyBlock(now); shouldTrigger {
+				log.Warn("paceMakerTimer fixed mode keyblock trigger", "chainElapsed", chainElapsed, "localElapsed", localElapsed)
 				t.setNextLeader(true)
 				continue
 			}
-			t.mu.Unlock()
 		}
 
 		diff := now.Sub(startTime)
@@ -166,6 +163,26 @@ func (t *paceMakerTimer) loopTimer() {
 			t.retryNumber++
 		}
 	}
+}
+
+func (t *paceMakerTimer) shouldTriggerFixedModeKeyBlock(now time.Time) (time.Duration, time.Duration, bool) {
+	keyblock := t.kbc.CurrentBlock()
+	if keyblock == nil {
+		return 0, 0, false
+	}
+	chainElapsed := now.Sub(time.Unix(int64(keyblock.Time()), 0))
+	if chainElapsed < fixedModeKeyBlockInterval {
+		return chainElapsed, 0, false
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	localElapsed := now.Sub(t.lastKeyTime)
+	if localElapsed < fixedModeTriggerThrottle {
+		return chainElapsed, localElapsed, false
+	}
+	t.lastKeyTime = now
+	return chainElapsed, localElapsed, true
 }
 
 func (t *paceMakerTimer) setNextLeader(isDone bool) {

--- a/reconfig/service.go
+++ b/reconfig/service.go
@@ -318,20 +318,10 @@ func (s *Service) Propose() (e error, kState []byte, tState []byte, extra []byte
 	s.muCurrentView.Unlock()
 
 	fixedMode := s.keyService.config != nil && (s.keyService.config.FixedLeader || s.keyService.config.FixedCommittee)
-	forceFixedTimedKeyBlock := false
-	if fixedMode && noDone {
-		curKeyBlock := s.kbc.CurrentBlock()
-		if curKeyBlock != nil {
-			lastKeyTime := time.Unix(int64(curKeyBlock.Time()), 0)
-			if time.Since(lastKeyTime) >= fixedModeKeyBlockInterval {
-				forceFixedTimedKeyBlock = true
-				log.Warn("Propose force fixed-mode timed keyblock", "elapsed", time.Since(lastKeyTime), "keyNumber", curKeyBlock.NumberU64(), "txNumber", s.bc.CurrentBlockN())
-			}
-		}
-	}
-	shouldProposeKeyBlock := leaderIndex > 0 || (fixedMode && (!noDone || forceFixedTimedKeyBlock))
+	// Fixed-mode timed keyblock triggering is centralized in paceMakerTimer.loopTimer.
+	shouldProposeKeyBlock := leaderIndex > 0 || (fixedMode && !noDone)
 	if shouldProposeKeyBlock {
-		isDoneKeyBlock := !noDone || forceFixedTimedKeyBlock
+		isDoneKeyBlock := !noDone
 		keyblock, mb, bestCandi, err := s.keyService.tryProposalChangeCommittee(leaderIndex, isDoneKeyBlock)
 		if err == nil && keyblock != nil && mb != nil {
 			if bestCandi != nil {


### PR DESCRIPTION
### Motivation

- Restore and enforce proper keyblock type/timing validation that was previously commented out to prevent invalid keyblock transitions.
- Harden fixed-mode verification to reject inconsistent best-candidate/pow-carrier combinations.
- Prevent unintended rapid successive fixed-mode keyblock triggers by centralizing logic in the pacemaker and adding a throttle.

### Description

- Reimplemented `KeyBlock.TypeCheck` to validate `T_Number` monotonicity and enforce modular constraints for `PowReconfig`, `PacePowReconfig`, `TimeReconfig`, and `PaceReconfig` using values from `params`.
- Strengthened verification in `reconfig/keyblock.go` to reject cases where fixed mode provides a best candidate but the keyblock lacks pow-carrier fields, and kept existing checks that require a best candidate when pow-carrier fields are set.
- Fixed leader selection bug by correctly advancing `curblock` inside the loop in `getNextLeaderIndex`, preventing repeated inspection of the same block ancestor, and added minor import adjustments.
- Updated `paceMakerTimer` to hold a reference to `KeyBlockChain`, introduced `fixedModeTriggerThrottle`, centralized fixed-mode timed keyblock triggering into `shouldTriggerFixedModeKeyBlock(now)` which checks both chain elapsed time and a local throttle and updates `lastKeyTime`; removed ad-hoc forcing from `Service.Propose` to avoid duplicate triggers.

### Testing

- Ran `go test ./...` across the repository which executed unit tests for `reconfig` and `core` packages and all tests passed.
- Built and ran the integration smoke test for the reconfiguration flow which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e326acd22c8330be04fc0ab7eee8c6)