### PR TITLE
fix: replace undefined GapTxBlocks constant in keyblock TypeCheck

### DIFF
--- a/core/types/keyblock.go
+++ b/core/types/keyblock.go
@@ -256,9 +256,9 @@ func (b *KeyBlock) TypeCheck(last_T_Number uint64) bool {
 	} else if keyType == PacePowReconfig {
 		return delta%params.KeyblockPerTxBlocks != 0
 	} else if keyType == TimeReconfig {
-		return delta%params.GapTxBlocks == 0
+		return delta%params.KeyblockPerTxBlocks == 0
 	} else if keyType == PaceReconfig {
-		return delta%params.GapTxBlocks != 0
+		return delta%params.KeyblockPerTxBlocks != 0
 	}
 	return false
 }


### PR DESCRIPTION
### Motivation
- The `KeyBlock.TypeCheck` function referenced a nonexistent `params.GapTxBlocks` constant which caused a compile-time error; the code should use the existing keyblock interval constant instead.

### Description
- Replaced `params.GapTxBlocks` with `params.KeyblockPerTxBlocks` in `core/types/keyblock.go` inside `KeyBlock.TypeCheck` for the `TimeReconfig` and `PaceReconfig` branches.

### Testing
- Ran `make cypher`; prior to this change it failed with `undefined: params.GapTxBlocks`, and after the change `make cypher` now fails only due to module/GOPATH environment issues (`go.mod`/module resolution), not the edited symbol. 
- Ran `GO111MODULE=off go test ./core/types`; the test run failed due to unresolved import paths in the container environment and could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e32bdce82883308b9a500e299f9604)