### PR TITLE
Set keyblock metadata before reward accumulation when proposing key blocks

### DIFF
--- a/reconfig/txblock.go
+++ b/reconfig/txblock.go
@@ -80,10 +80,6 @@ func (txS *txService) tryProposalNewKeyBlock(keyblock *types.KeyBlock) ([]byte, 
 	work := txS.createWork()
 
 	header := work.header
-	// commit state root after all state transitions.
-	colossusX.AccumulateRewards(txS.bc.Config(), work.publicState, header, nil)
-	header.Root = work.publicState.IntermediateRoot(txS.bc.Config().IsEIP158(header.Number))
-
 	header.BlockType = types.Key_Block
 	header.Difficulty = keyblock.Difficulty()
 	header.MixDigest = keyblock.MixDigest()
@@ -92,6 +88,11 @@ func (txS *txService) tryProposalNewKeyBlock(keyblock *types.KeyBlock) ([]byte, 
 
 	block := types.NewBlock(header, nil, nil, nil, new(trie.Trie))
 	block.SetKeyblock(keyblock)
+	// commit state root after all state transitions.
+	// Important: keyblock metadata must be set before reward accumulation so that
+	// rewardCommonNodePow can evaluate keyblock type/address deterministically.
+	colossusX.AccumulateRewards(txS.bc.Config(), work.publicState, block.Header0(), nil)
+	block.Header0().Root = work.publicState.IntermediateRoot(txS.bc.Config().IsEIP158(block.Number()))
 
 	log.Info("Generated next keyblock", "block num", block.Number())
 


### PR DESCRIPTION
### Motivation
- Ensure reward accumulation logic can deterministically inspect keyblock metadata by setting the block's keyblock header before calling the reward accumulator, preventing incorrect state root computation.

### Description
- Move the call to `colossusX.AccumulateRewards` and the `Root` assignment to after `types.NewBlock(...).SetKeyblock(keyblock)` and use `block.Header0()` when accumulating rewards and computing `IntermediateRoot`.

### Testing
- Built the project with `go build` and ran unit tests with `go test ./...`, and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e335a14d5c8330a07717d489c17c05)