### PR TITLE
Add transaction route hints and tighten fast-lane limits; adjust txpool and block selection thresholds

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -148,8 +148,8 @@ const (
 )
 
 const (
-	txLaneFastMaxDataBytes = 1024
-	txLaneFastMaxGasPerTx  = uint64(300000)
+	txLaneFastMaxDataBytes = 256
+	txLaneFastMaxGasPerTx  = uint64(120000)
 )
 
 // blockChain provides the state of blockchain and current gas limit to do
@@ -204,11 +204,11 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	AccountQueue: 4096,
 	GlobalQueue:  1000000,
 
-	RemoteAccountWindow: 1024,
-	LocalAccountWindow:  64,
-	FastPendingLifetime: 2 * time.Minute,
+	RemoteAccountWindow: 8,
+	LocalAccountWindow:  8,
+	FastPendingLifetime: 30 * time.Second,
 	SlowPendingLifetime: 10 * time.Minute,
-	FastQueuedLifetime:  5 * time.Minute,
+	FastQueuedLifetime:  2 * time.Minute,
 	SlowQueuedLifetime:  30 * time.Minute,
 
 	Lifetime: 3 * time.Hour,
@@ -599,6 +599,15 @@ func ClassifyTxLane(tx *types.Transaction) TxLane {
 	if tx == nil {
 		return TxLaneSlow
 	}
+
+	// Explicit routing wins.
+	switch tx.RouteHint() {
+	case types.TxRouteSlow:
+		return TxLaneSlow
+	case types.TxRouteFast:
+		return TxLaneFast
+	}
+
 	if tx.To() == nil {
 		return TxLaneSlow
 	}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -40,14 +40,23 @@ var (
 )
 
 type Transaction struct {
-	data txdata    // Consensus contents of a transaction
-	time time.Time // Time first seen locally (spam avoidance)
+	data      txdata      // Consensus contents of a transaction
+	routeHint TxRouteHint // Non-consensus local route hint
+	time      time.Time   // Time first seen locally (spam avoidance)
 
 	// caches
 	hash atomic.Value
 	size atomic.Value
 	from atomic.Value
 }
+
+type TxRouteHint uint8
+
+const (
+	TxRouteAuto TxRouteHint = iota
+	TxRouteFast
+	TxRouteSlow
+)
 
 type txdata struct {
 	AccountNonce uint64          `json:"nonce"    gencodec:"required"`
@@ -182,6 +191,16 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 }
 
 func (tx *Transaction) Data() []byte       { return common.CopyBytes(tx.data.Payload) }
+func (tx *Transaction) RouteHint() TxRouteHint {
+	return tx.routeHint
+}
+
+func (tx *Transaction) WithRouteHint(hint TxRouteHint) *Transaction {
+	cpy := *tx
+	cpy.routeHint = hint
+	return &cpy
+}
+
 func (tx *Transaction) V() *big.Int        { return tx.data.V }
 func (tx *Transaction) Gas() uint64        { return tx.data.GasLimit }
 func (tx *Transaction) GasPrice() *big.Int { return new(big.Int).Set(tx.data.Price) }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -21,15 +21,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/cypherium/cypher/accounts"
+	"github.com/cypherium/cypher/accounts/abi"
+	"github.com/cypherium/cypher/accounts/keystore"
+	"github.com/davecgh/go-spew/spew"
 	"math/big"
 	"net"
 	"strings"
 	"sync/atomic"
 	"time"
-	"github.com/cypherium/cypher/accounts"
-	"github.com/cypherium/cypher/accounts/abi"
-	"github.com/cypherium/cypher/accounts/keystore"
-	"github.com/davecgh/go-spew/spew"
 
 	//"github.com/cypherium/cypher/accounts/scwallet"
 	"github.com/cypherium/cypher/common"
@@ -45,9 +45,9 @@ import (
 	"github.com/cypherium/cypher/p2p"
 	"github.com/cypherium/cypher/params"
 
+	"github.com/cypherium/cypher/reconfig/bftview"
 	"github.com/cypherium/cypher/rlp"
 	"github.com/cypherium/cypher/rpc"
-	"github.com/cypherium/cypher/reconfig/bftview"
 )
 
 type TransactionType uint8
@@ -624,16 +624,16 @@ func (s *PublicBlockChainAPI) KeyBlockNumber() hexutil.Uint64 {
 }
 
 func (s *PublicBlockChainAPI) RescueCommittee(args bftview.RescueCommitteeArgs) (bool, error) {
-    committee, keyBlockHash, err := s.b.RescueCommittee(args.ConfigPath)
-    if err != nil {
-        return false, err
-    }
+	committee, keyBlockHash, err := s.b.RescueCommittee(args.ConfigPath)
+	if err != nil {
+		return false, err
+	}
 	if (keyBlockHash == common.Hash{}) {
-        return false, errors.New("key block hash is empty (invalid config)")
-    }
-    keyblock := s.b.GetKeyBlockChain().GetBlockByHash(keyBlockHash)
-    bftview.SetRescueMode(keyblock.NumberU64(), keyblock.Hash(), committee)
-    return true, nil
+		return false, errors.New("key block hash is empty (invalid config)")
+	}
+	keyblock := s.b.GetKeyBlockChain().GetBlockByHash(keyBlockHash)
+	bftview.SetRescueMode(keyblock.NumberU64(), keyblock.Hash(), committee)
+	return true, nil
 }
 
 // GetBalance returns the amount of wei for the given address in the state of the
@@ -741,10 +741,10 @@ func (s *PublicBlockChainAPI) GetHeaderByHash(ctx context.Context, hash common.H
 }
 
 // GetBlockByNumber returns the requested canonical block.
-// * When blockNr is -1 the chain head is returned.
-// * When blockNr is -2 the pending chain head is returned.
-// * When fullTx is true all transactions in the block are returned, otherwise
-//   only the transaction hash is returned.
+//   - When blockNr is -1 the chain head is returned.
+//   - When blockNr is -2 the pending chain head is returned.
+//   - When fullTx is true all transactions in the block are returned, otherwise
+//     only the transaction hash is returned.
 func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
 	block, err := s.b.BlockByNumber(ctx, number)
 	if block != nil && err == nil {
@@ -871,6 +871,7 @@ func (s *PublicBlockChainAPI) GetCommitteeMember(ctx context.Context, blockNr rp
 	}
 	return nil, err
 }
+
 // GetCode returns the code stored at the given address in the state for the given block number.
 func (s *PublicBlockChainAPI) GetCode(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (hexutil.Bytes, error) {
 	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
@@ -1659,6 +1660,10 @@ type SendTxArgs struct {
 	Input *hexutil.Bytes `json:"input"`
 }
 
+type SendTxOpts struct {
+	UseSlowLane bool `json:"useSlowLane"`
+}
+
 // setDefaults is a helper function that fills in default values for unspecified tx fields.
 func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 	if args.GasPrice == nil {
@@ -1785,6 +1790,43 @@ func (s *PublicTransactionPoolAPI) SendTransaction(ctx context.Context, args Sen
 
 	// Assemble the transaction and sign with the wallet
 	tx := args.toTransaction()
+
+	var chainID *big.Int
+	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) {
+		chainID = config.ChainID
+	}
+
+	signed, err := wallet.SignTx(account, tx, chainID)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	return SubmitTransaction(ctx, s.b, signed, true)
+}
+
+func (s *PublicTransactionPoolAPI) SendTransactionWithOpts(ctx context.Context, args SendTxArgs, opts SendTxOpts) (common.Hash, error) {
+	// Look up the wallet containing the requested signer
+	account := accounts.Account{Address: args.From}
+
+	wallet, err := s.b.AccountManager().Find(account)
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	if args.Nonce == nil {
+		s.nonceLock.LockAddr(args.From)
+		defer s.nonceLock.UnlockAddr(args.From)
+	}
+
+	if err := args.setDefaults(ctx, s.b); err != nil {
+		return common.Hash{}, err
+	}
+
+	tx := args.toTransaction()
+	if opts.UseSlowLane {
+		tx = tx.WithRouteHint(types.TxRouteSlow)
+	} else {
+		tx = tx.WithRouteHint(types.TxRouteFast)
+	}
 
 	var chainID *big.Int
 	if config := s.b.ChainConfig(); config.IsEIP155(s.b.CurrentBlock().Number()) {

--- a/reconfig/service.go
+++ b/reconfig/service.go
@@ -39,8 +39,9 @@ import (
 const failedProposalRetry = 200 * time.Millisecond
 const hotstuffIdleSleep = 10 * time.Millisecond
 const tryProposeDebounce = 5 * time.Millisecond
-const slowBlockMinPending = 16
-const slowBlockMinInterval = 300 * time.Millisecond
+const fastBlockInterval = 1 * time.Second
+const slowBlockInterval = 1 * time.Minute
+const slowFallbackMinPending = 1
 
 type committeeInfo struct {
 	Committee *bftview.Committee
@@ -111,6 +112,8 @@ type Service struct {
 	runningState       int32
 	lastProposeTime    time.Time
 	lastSlowBlockTime  time.Time
+	lastFastBlockTime  time.Time
+	serviceStartTime   time.Time
 	tryProposeQueuedAt int64
 	pacetMakerTimer    *paceMakerTimer
 
@@ -122,6 +125,7 @@ type Service struct {
 
 func newService(sName, sIp string, chainConfig *params.ChainConfig, backend *ReconfigBackend) *Service {
 	s := new(Service)
+	s.serviceStartTime = time.Now()
 	s.netService = newNetService(sName, sIp, chainConfig, backend, s)
 	s.txService = newTxService(s, backend, chainConfig)
 	s.keyService = newKeyService(s, backend, chainConfig)
@@ -377,8 +381,11 @@ func (s *Service) Propose() (e error, kState []byte, tState []byte, extra []byte
 		log.Warn("tryProposalNewBlock", "error", err)
 		return err, nil, nil, nil
 	}
+	now := time.Now()
 	if blockType == types.SlowTx_Block {
-		s.lastSlowBlockTime = time.Now()
+		s.lastSlowBlockTime = now
+	} else if blockType == types.FastTx_Block {
+		s.lastFastBlockTime = now
 	}
 	proposeOK = true
 	return nil, nil, data, nil
@@ -414,6 +421,20 @@ func readableTxBlockType(blockType uint8) string {
 	}
 }
 
+func (s *Service) shouldEmitFastBlock(now time.Time) bool {
+	if s.lastFastBlockTime.IsZero() {
+		return true
+	}
+	return now.Sub(s.lastFastBlockTime) >= fastBlockInterval
+}
+
+func (s *Service) shouldEmitSlowBlock(now time.Time) bool {
+	if s.lastSlowBlockTime.IsZero() {
+		return true
+	}
+	return now.Sub(s.lastSlowBlockTime) >= slowBlockInterval
+}
+
 func (s *Service) lanePendingCounts() (fastPending int, slowPending int) {
 	fastAddrTxes, fastErr := s.txService.loadPendingAddressTxes(types.FastTx_Block)
 	if fastErr != nil {
@@ -434,35 +455,19 @@ func (s *Service) lanePendingCounts() (fastPending int, slowPending int) {
 
 func (s *Service) chooseTxBlockType() uint8 {
 	fastPending, slowPending := s.lanePendingCounts()
-	lastSlowAgo := time.Duration(0)
-	if !s.lastSlowBlockTime.IsZero() {
-		lastSlowAgo = time.Since(s.lastSlowBlockTime)
-	}
-
-	blockType := uint8(types.FastTx_Block)
+	now := time.Now()
 	switch {
-	case slowPending == 0:
-		blockType = types.FastTx_Block
-	case fastPending == 0:
-		blockType = types.SlowTx_Block
-	case slowPending == fastPending:
-		// All currently proposal-eligible heads are fast-lane transactions.
-		// Prefer fast blocks so simple transfers never get dragged into the slow path.
-		blockType = types.FastTx_Block
-	case slowPending >= slowBlockMinPending &&
-		(s.lastSlowBlockTime.IsZero() || time.Since(s.lastSlowBlockTime) >= slowBlockMinInterval):
-		blockType = types.SlowTx_Block
+	case fastPending > 0 && s.shouldEmitFastBlock(now):
+		return types.FastTx_Block
+	case slowPending > 0 && s.shouldEmitSlowBlock(now):
+		return types.SlowTx_Block
+	case fastPending > 0:
+		return types.FastTx_Block
+	case slowPending >= slowFallbackMinPending:
+		return types.SlowTx_Block
 	default:
-		blockType = types.FastTx_Block
+		return types.FastTx_Block
 	}
-
-	log.Debug("chooseTxBlockType",
-		"fastPending", fastPending,
-		"slowPending", slowPending,
-		"lastSlowAgo", lastSlowAgo,
-		"chosen", readableTxBlockType(blockType))
-
-	return blockType
 }
 
 // OnViewDone call by hotstuff

--- a/reconfig/txblock.go
+++ b/reconfig/txblock.go
@@ -279,17 +279,17 @@ const (
 	pendingTierMedium = 256
 	pendingTierLarge  = 1024
 
-	fastPerAccountTierSmall  = 16
-	slowPerAccountTierSmall  = 8
-	fastPerAccountTierMedium = 48
-	slowPerAccountTierMedium = 32
-	fastPerAccountTierLarge  = 192
+	fastPerAccountTierSmall  = 4
+	slowPerAccountTierSmall  = 16
+	fastPerAccountTierMedium = 8
+	slowPerAccountTierMedium = 48
+	fastPerAccountTierLarge  = 16
 	slowPerAccountTierLarge  = 128
-	fastBlockMaxTxCount      = uint64(20000)
-	slowBlockMaxTxCount      = uint64(40000)
-	fastBlockMaxGasPerTx     = uint64(300000)
-	fastBlockMaxDataBytes    = 1024
-	fastBlockGasTargetPct    = uint64(94)
+	fastBlockMaxTxCount      = uint64(4000)
+	slowBlockMaxTxCount      = uint64(50000)
+	fastBlockMaxGasPerTx     = uint64(120000)
+	fastBlockMaxDataBytes    = 256
+	fastBlockGasTargetPct    = uint64(35)
 	slowBlockGasTargetPct    = uint64(98)
 )
 
@@ -356,6 +356,9 @@ func fastEligibleTx(tx *types.Transaction) bool {
 	if tx == nil {
 		return false
 	}
+	if tx.RouteHint() == types.TxRouteSlow {
+		return false
+	}
 	if tx.To() == nil {
 		return false
 	}
@@ -365,7 +368,18 @@ func fastEligibleTx(tx *types.Transaction) bool {
 	if tx.Gas() > fastBlockMaxGasPerTx {
 		return false
 	}
-	return true
+	if len(tx.Data()) == 0 {
+		return true
+	}
+	// conservative allowlist for fast lane
+	if len(tx.Data()) >= 4 &&
+		tx.Data()[0] == 0xa9 &&
+		tx.Data()[1] == 0x05 &&
+		tx.Data()[2] == 0x9c &&
+		tx.Data()[3] == 0xbb {
+		return true
+	}
+	return false
 }
 
 func selectTxsForBlockType(addrTxes AddressTxes, blockType uint8, perAccount int) AddressTxes {


### PR DESCRIPTION
### Motivation

- Introduce an explicit, local route hint for transactions to allow forcing a tx into the fast or slow lane and to make fast-lane routing deterministic. 
- Reduce fast-lane resource allowances and make block selection more time-aware to improve fairness and prevent heavy transactions from occupying the fast path. 

### Description

- Add a `routeHint` field to `types.Transaction` and a `TxRouteHint` enum with helpers `RouteHint()` and `WithRouteHint()` to annotate non-consensus routing preferences. 
- Update transaction lane classification in `ClassifyTxLane` to honour explicit `RouteHint()` values before applying size/gas heuristics. 
- Expose a new RPC helper `SendTransactionWithOpts` and `SendTxOpts` with `UseSlowLane` to let callers request the slow lane when submitting transactions. 
- Tighten fast-lane limits and pool defaults by lowering `fast` data/gas caps and reducing account/window/timeout sizes in `DefaultTxPoolConfig` and relevant constants in `reconfig/txblock.go` and `core/tx_pool.go`. 
- Harden fast-block selection and eligibility: `fastEligibleTx` now rejects txs with `RouteHint == TxRouteSlow`, requires empty payloads or a conservative allowlist (function selector `0xa9059cbb`), and `chooseTxBlockType` now considers recent fast/slow emission times via `shouldEmitFastBlock`/`shouldEmitSlowBlock`. 

### Testing

- Built the project with `go build ./...` which completed successfully. 
- Ran unit tests with `go test ./...` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b3f905308330aeaa5046bd9ed0f5)