### PR TITLE
Promote routeHint to tx payload and centralize fast-lane eligibility

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -152,6 +152,39 @@ const (
 	txLaneFastMaxGasPerTx  = uint64(120000)
 )
 
+func IsFastLaneEligible(tx *types.Transaction) bool {
+	if tx == nil {
+		return false
+	}
+	switch tx.RouteHint() {
+	case types.TxRouteSlow:
+		return false
+	case types.TxRouteFast:
+		// keep checking hard safety bounds
+	}
+	if tx.To() == nil {
+		return false
+	}
+	if len(tx.Data()) > txLaneFastMaxDataBytes {
+		return false
+	}
+	if tx.Gas() > txLaneFastMaxGasPerTx {
+		return false
+	}
+	if len(tx.Data()) == 0 {
+		return true
+	}
+	// ERC20 transfer(address,uint256)
+	if len(tx.Data()) >= 4 &&
+		tx.Data()[0] == 0xa9 &&
+		tx.Data()[1] == 0x05 &&
+		tx.Data()[2] == 0x9c &&
+		tx.Data()[3] == 0xbb {
+		return true
+	}
+	return false
+}
+
 // blockChain provides the state of blockchain and current gas limit to do
 // some pre checks in tx pool and event subscribers.
 type blockChain interface {
@@ -596,28 +629,10 @@ func (pool *TxPool) local() map[common.Address]types.Transactions {
 // validateTx checks whether a transaction is valid according to the consensus
 
 func ClassifyTxLane(tx *types.Transaction) TxLane {
-	if tx == nil {
-		return TxLaneSlow
-	}
-
-	// Explicit routing wins.
-	switch tx.RouteHint() {
-	case types.TxRouteSlow:
-		return TxLaneSlow
-	case types.TxRouteFast:
+	if IsFastLaneEligible(tx) {
 		return TxLaneFast
 	}
-
-	if tx.To() == nil {
-		return TxLaneSlow
-	}
-	if len(tx.Data()) > txLaneFastMaxDataBytes {
-		return TxLaneSlow
-	}
-	if tx.Gas() > txLaneFastMaxGasPerTx {
-		return TxLaneSlow
-	}
-	return TxLaneFast
+	return TxLaneSlow
 }
 
 func (pool *TxPool) accountWindow(local bool) uint64 {

--- a/core/types/gen_tx_json.go
+++ b/core/types/gen_tx_json.go
@@ -22,6 +22,7 @@ func (t txdata) MarshalJSON() ([]byte, error) {
 		Recipient    *common.Address `json:"to"       rlp:"nil"`
 		Amount       *hexutil.Big    `json:"value"    gencodec:"required"`
 		Payload      hexutil.Bytes   `json:"input"    gencodec:"required"`
+		RouteHint    TxRouteHint     `json:"routeHint,omitempty"`
 		V            *hexutil.Big    `json:"v" gencodec:"required"`
 		R            *hexutil.Big    `json:"r" gencodec:"required"`
 		S            *hexutil.Big    `json:"s" gencodec:"required"`
@@ -34,6 +35,7 @@ func (t txdata) MarshalJSON() ([]byte, error) {
 	enc.Recipient = t.Recipient
 	enc.Amount = (*hexutil.Big)(t.Amount)
 	enc.Payload = t.Payload
+	enc.RouteHint = t.RouteHint
 	enc.V = (*hexutil.Big)(t.V)
 	enc.R = (*hexutil.Big)(t.R)
 	enc.S = (*hexutil.Big)(t.S)
@@ -50,6 +52,7 @@ func (t *txdata) UnmarshalJSON(input []byte) error {
 		Recipient    *common.Address `json:"to"       rlp:"nil"`
 		Amount       *hexutil.Big    `json:"value"    gencodec:"required"`
 		Payload      *hexutil.Bytes  `json:"input"    gencodec:"required"`
+		RouteHint    *TxRouteHint    `json:"routeHint,omitempty"`
 		V            *hexutil.Big    `json:"v" gencodec:"required"`
 		R            *hexutil.Big    `json:"r" gencodec:"required"`
 		S            *hexutil.Big    `json:"s" gencodec:"required"`
@@ -82,6 +85,9 @@ func (t *txdata) UnmarshalJSON(input []byte) error {
 		return errors.New("missing required field 'input' for txdata")
 	}
 	t.Payload = *dec.Payload
+	if dec.RouteHint != nil {
+		t.RouteHint = *dec.RouteHint
+	}
 	if dec.V == nil {
 		return errors.New("missing required field 'v' for txdata")
 	}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -40,9 +40,8 @@ var (
 )
 
 type Transaction struct {
-	data      txdata      // Consensus contents of a transaction
-	routeHint TxRouteHint // Non-consensus local route hint
-	time      time.Time   // Time first seen locally (spam avoidance)
+	data txdata    // Consensus / wire contents of a transaction
+	time time.Time // Time first seen locally (spam avoidance)
 
 	// caches
 	hash atomic.Value
@@ -65,6 +64,7 @@ type txdata struct {
 	Recipient    *common.Address `json:"to"       rlp:"nil"` // nil means contract creation
 	Amount       *big.Int        `json:"value"    gencodec:"required"`
 	Payload      []byte          `json:"input"    gencodec:"required"`
+	RouteHint    TxRouteHint     `json:"routeHint,omitempty"`
 
 	// Signature values
 	V *big.Int `json:"v" gencodec:"required"`
@@ -190,14 +190,14 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
-func (tx *Transaction) Data() []byte       { return common.CopyBytes(tx.data.Payload) }
+func (tx *Transaction) Data() []byte { return common.CopyBytes(tx.data.Payload) }
 func (tx *Transaction) RouteHint() TxRouteHint {
-	return tx.routeHint
+	return tx.data.RouteHint
 }
 
 func (tx *Transaction) WithRouteHint(hint TxRouteHint) *Transaction {
 	cpy := *tx
-	cpy.routeHint = hint
+	cpy.data.RouteHint = hint
 	return &cpy
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1992,6 +1992,20 @@ func (s *PublicTransactionPoolAPI) SendRawTransaction(ctx context.Context, encod
 	return SubmitTransaction(ctx, s.b, tx, true)
 }
 
+func (s *PublicTransactionPoolAPI) SendRawTransactionWithOpts(ctx context.Context, encodedTx hexutil.Bytes, opts SendTxOpts) (common.Hash, error) {
+	log.Info("SendRawTransactionWithOpts")
+	tx := new(types.Transaction)
+	if err := rlp.DecodeBytes(encodedTx, tx); err != nil {
+		return common.Hash{}, err
+	}
+	if opts.UseSlowLane {
+		tx = tx.WithRouteHint(types.TxRouteSlow)
+	} else {
+		tx = tx.WithRouteHint(types.TxRouteFast)
+	}
+	return SubmitTransaction(ctx, s.b, tx, true)
+}
+
 // Sign calculates an ECDSA signature for:
 // keccack256("\x19Ethereum Signed Message:\n" + len(message) + message).
 //

--- a/reconfig/service.go
+++ b/reconfig/service.go
@@ -114,6 +114,7 @@ type Service struct {
 	lastSlowBlockTime  time.Time
 	lastFastBlockTime  time.Time
 	serviceStartTime   time.Time
+	lastCadenceWakeup  time.Time
 	tryProposeQueuedAt int64
 	pacetMakerTimer    *paceMakerTimer
 
@@ -545,6 +546,15 @@ func (s *Service) handleHotStuffMsg() {
 		data := s.hotstuffMsgQ.PopFront()
 		if data == nil {
 			time.Sleep(hotstuffIdleSleep)
+			now := time.Now()
+			if bftview.IamLeader(s.GetCurrentView().LeaderIndex) {
+				if s.shouldEmitFastBlock(now) || s.shouldEmitSlowBlock(now) {
+					if s.lastCadenceWakeup.IsZero() || now.Sub(s.lastCadenceWakeup) >= 50*time.Millisecond {
+						s.lastCadenceWakeup = now
+						s.triggerTryPropose(s.bc.CurrentBlockN())
+					}
+				}
+			}
 			s.protocolMng.HandleMessage(&hotstuff.HotstuffMessage{Code: hotstuff.MsgTimer, Number: s.bc.CurrentBlockN()})
 			continue
 		}

--- a/reconfig/txblock.go
+++ b/reconfig/txblock.go
@@ -287,8 +287,6 @@ const (
 	slowPerAccountTierLarge  = 128
 	fastBlockMaxTxCount      = uint64(4000)
 	slowBlockMaxTxCount      = uint64(50000)
-	fastBlockMaxGasPerTx     = uint64(120000)
-	fastBlockMaxDataBytes    = 256
 	fastBlockGasTargetPct    = uint64(35)
 	slowBlockGasTargetPct    = uint64(98)
 )
@@ -353,33 +351,7 @@ func limitAddressTxes(addrTxes AddressTxes, perAccount int) AddressTxes {
 }
 
 func fastEligibleTx(tx *types.Transaction) bool {
-	if tx == nil {
-		return false
-	}
-	if tx.RouteHint() == types.TxRouteSlow {
-		return false
-	}
-	if tx.To() == nil {
-		return false
-	}
-	if len(tx.Data()) > fastBlockMaxDataBytes {
-		return false
-	}
-	if tx.Gas() > fastBlockMaxGasPerTx {
-		return false
-	}
-	if len(tx.Data()) == 0 {
-		return true
-	}
-	// conservative allowlist for fast lane
-	if len(tx.Data()) >= 4 &&
-		tx.Data()[0] == 0xa9 &&
-		tx.Data()[1] == 0x05 &&
-		tx.Data()[2] == 0x9c &&
-		tx.Data()[3] == 0xbb {
-		return true
-	}
-	return false
+	return core.IsFastLaneEligible(tx)
 }
 
 func selectTxsForBlockType(addrTxes AddressTxes, blockType uint8, perAccount int) AddressTxes {


### PR DESCRIPTION
### Motivation
- Ensure `routeHint` is carried across the wire and visible in JSON/RPC so routing hints survive raw-RLP propagation and peer-to-peer relays.
- Eliminate duplicated fast/slow lane heuristics between txpool and proposer to avoid inconsistent lane classification across components.
- Provide a short-term API to allow lane selection for raw-RLP submission during the transition to payload-embedded routing hints.

### Description
- Move `routeHint` from the outer `Transaction` field into the RLP/JSON-serializable `txdata` as `RouteHint`, and update `RouteHint()` and `WithRouteHint()` to read/write `tx.data.RouteHint` (file: `core/types/transaction.go`).
- Extend the generated JSON marshal/unmarshal code to include `routeHint` in RPC representations (file: `core/types/gen_tx_json.go`).
- Add `core.IsFastLaneEligible(tx *types.Transaction) bool` that centralizes the fast-lane eligibility logic and refactor `ClassifyTxLane` to use it (file: `core/tx_pool.go`).
- Change the proposer-side check to call the shared eligibility function (`core.IsFastLaneEligible`) and remove duplicated per-tx thresholds from `reconfig/txblock.go` so pool/proposer decisions align.
- Add `SendRawTransactionWithOpts` to `PublicTransactionPoolAPI` to allow setting `SendTxOpts.UseSlowLane` for raw-RLP submission during the migration (file: `internal/ethapi/api.go`).
- Add a lightweight cadence wakeup in `handleHotStuffMsg` idle loop with a `lastCadenceWakeup` debounce to trigger proposal attempts when the node is leader (file: `reconfig/service.go`).

### Testing
- Ran `gofmt -w` on all modified files successfully to ensure formatting compliance.
- Attempted `go test ./core/types ./core ./reconfig ./internal/ethapi` but the test run failed in this environment due to module/GOPATH dependency resolution errors (no module initialization and unresolved external imports), so package tests could not be executed here.
- Also attempted `GO111MODULE=off go test ...` which similarly failed due to missing dependencies in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b9d0323c83308080bf5a95c90d26)