### PR TITLE
Apply fixed-mode keyblock PoW reward to submitter and invoke during block proposal

### DIFF
--- a/consensus/colossusX/consensus.go
+++ b/consensus/colossusX/consensus.go
@@ -141,7 +141,7 @@ func calcKeyBlockDifficultyByzantium(time uint64, parent *types.KeyBlockHeader) 
 	return x
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////
 // VerifyCandidate implements pow.Engine, checking whether the given candidate satisfies
 // the PoW difficulty requirements.
 func (colossusX *colossusX) VerifyCandidate(chain types.KeyChainReader, candidate *types.Candidate) error {
@@ -253,7 +253,7 @@ func (colossusX *colossusX) PowMode() uint {
 	return uint(colossusX.config.PowMode)
 }
 
-//----------------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------
 // Author implements consensus.Engine, returning the header's coinbase as the
 // proof-of-work verified author of the block.
 func (colossusX *colossusX) Author(header *types.Header) (common.Address, error) {
@@ -525,6 +525,41 @@ func accumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 // wrapper for accumulateRewards to be called by raft minter
 func AccumulateRewards(config *params.ChainConfig, state *state.StateDB, header *types.Header, uncles []*types.Header) {
 	accumulateRewards(config, state, header, uncles)
+}
+
+// ApplyFixedModeKeyblockPowReward credits the keyblock reward to the PoW submitter
+// adopted by a fixed-mode time/pace keyblock.
+func ApplyFixedModeKeyblockPowReward(bc types.ChainReader, state vm.StateDB, header *types.Header) {
+	if bc == nil || state == nil || header == nil || header.Number == nil || header.Number.Sign() == 0 {
+		return
+	}
+	cfg := bc.Config()
+	if cfg == nil || (!cfg.FixedLeader && !cfg.FixedCommittee) {
+		return
+	}
+
+	pBlock := bc.GetBlock(header.ParentHash, header.Number.Uint64()-1)
+	if pBlock == nil {
+		log.Error("ApplyFixedModeKeyblockPowReward", "not found parent header hash", header.ParentHash)
+		return
+	}
+	if header.KeyHash == pBlock.KeyHash() {
+		return
+	}
+
+	kheader := bc.GetKeyChainReader().GetHeaderByHash(header.KeyHash)
+	if kheader == nil || kheader.HasNewNode() {
+		return
+	}
+	kblock := bc.GetKeyChainReader().GetBlock(header.KeyHash, kheader.NumberU64())
+	if kblock == nil {
+		return
+	}
+	submitter := strings.TrimPrefix(kblock.OutAddress(0), "*")
+	if submitter == "" {
+		return
+	}
+	state.AddBalance(common.HexToAddress(submitter), big.NewInt(params.KeyBlock_Reward))
 }
 
 func RewardCommites(bc types.ChainReader, state vm.StateDB, header *types.Header, blockReward uint64, beNewVer bool) {

--- a/reconfig/txblock.go
+++ b/reconfig/txblock.go
@@ -127,10 +127,11 @@ func (txS *txService) tryProposalNewBlock(blockType uint8) ([]byte, error) {
 
 		header := work.header
 
+		header.KeyHash = txS.kbc.CurrentBlock().Hash()
 		// commit state root after all state transitions.
 		colossusX.AccumulateRewards(txS.bc.Config(), work.publicState, header, nil)
+		colossusX.ApplyFixedModeKeyblockPowReward(txS.bc, work.publicState, header)
 		header.Root = work.publicState.IntermediateRoot(false)
-		header.KeyHash = txS.kbc.CurrentBlock().Hash()
 		header.BlockType = blockType
 
 		// update block hash since it is now available, but was not when the


### PR DESCRIPTION
### Motivation
- Ensure that in fixed-mode time/pace keyblock configurations the PoW submitter receives the keyblock reward when a new block is proposed. 
- Apply the reward at block proposal time so state and receipts reflect the credit before committing the block root.

### Description
- Add `ApplyFixedModeKeyblockPowReward` which validates fixed-mode config, locates the parent/key keyblock, extracts the submitter address via `OutAddress(0)`, and credits `state` with `params.KeyBlock_Reward` when appropriate. 
- Call `colossusX.ApplyFixedModeKeyblockPowReward(txS.bc, work.publicState, header)` from `tryProposalNewBlock` and move `header.KeyHash = txS.kbc.CurrentBlock().Hash()` earlier so rewards are applied before computing `header.Root`. 
- Include nil/parent/key-header checks and skip crediting when the keyblock has a new node or submitter is empty; log an error when parent is missing. 
- Minor whitespace/comment formatting adjustments in `consensus/colossusX/consensus.go`.

### Testing
- Ran `go test ./...` across the repository and the test suite completed successfully. 
- Built the node binary and exercised the new block proposal path to verify no runtime panics and that the `ApplyFixedModeKeyblockPowReward` path is exercised in fixed-mode configurations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e9cfa2d08330851e0b496c953970)