### PR TITLE
Fix progress percentage calculation in DAG generation logging

### DIFF
--- a/consensus/colossusX/algorithm.go
+++ b/consensus/colossusX/algorithm.go
@@ -378,7 +378,7 @@ func generateDataset(dest []uint32, epoch uint64, cache []uint32) {
 				copy(dataset[int(offset):int(end)], item)
 
 				if status := atomic.AddUint32(&progress, 1); status%percent == 0 {
-					logger.Info("Generating DAG in progress", "percentage", uint64(status*100)/cells, "elapsed", common.PrettyDuration(time.Since(start)))
+					logger.Info("Generating DAG in progress", "percentage", uint64(status)*100/cells, "elapsed", common.PrettyDuration(time.Since(start)))
 				}
 			}
 		}(i)


### PR DESCRIPTION
### Motivation
- Correct integer conversion and operator precedence in the DAG generation progress log so percentage is calculated correctly and avoids unintended overflow.

### Description
- Replace `uint64(status*100)/cells` with `uint64(status)*100/cells` in `consensus/colossusX/algorithm.go` logging to ensure multiplication happens on a 64-bit value before division.

### Testing
- Ran `go test ./...` and a package build; automated tests and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e44f8f788330b009c32675cce1e7)