### PR TITLE
Credit KeyBlock_Reward to keyblock outAddress regardless of fixed-mode and HasNewNode

### DIFF
--- a/consensus/colossusX/consensus.go
+++ b/consensus/colossusX/consensus.go
@@ -527,14 +527,13 @@ func AccumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 	accumulateRewards(config, state, header, uncles)
 }
 
-// ApplyFixedModeKeyblockPowReward credits the keyblock reward to the PoW submitter
-// adopted by a fixed-mode time/pace keyblock.
+// ApplyFixedModeKeyblockPowReward credits KeyBlock_Reward to keyblock outAddress
+// when the tx chain switches to a new keyblock (first tx block after keyblock change).
+//
+// NOTE: despite the historical function name, this now applies to any keyblock
+// that has a non-empty outAddress in the keyblock body.
 func ApplyFixedModeKeyblockPowReward(bc types.ChainReader, state vm.StateDB, header *types.Header) {
 	if bc == nil || state == nil || header == nil || header.Number == nil || header.Number.Sign() == 0 {
-		return
-	}
-	cfg := bc.Config()
-	if cfg == nil || (!cfg.FixedLeader && !cfg.FixedCommittee) {
 		return
 	}
 
@@ -548,7 +547,7 @@ func ApplyFixedModeKeyblockPowReward(bc types.ChainReader, state vm.StateDB, hea
 	}
 
 	kheader := bc.GetKeyChainReader().GetHeaderByHash(header.KeyHash)
-	if kheader == nil || kheader.HasNewNode() {
+	if kheader == nil {
 		return
 	}
 	kblock := bc.GetKeyChainReader().GetBlock(header.KeyHash, kheader.NumberU64())


### PR DESCRIPTION
### Motivation

- Ensure the keyblock reward is credited to the keyblock's configured `outAddress` whenever the tx chain switches to a new keyblock, rather than only in fixed-mode configurations or being blocked by `HasNewNode`.

### Description

- Removed the chain config guard that required `FixedLeader` or `FixedCommittee` for `ApplyFixedModeKeyblockPowReward` to run.
- Removed the `kheader.HasNewNode()` check so the reward is applied even when that flag was previously present.
- Updated the function comment to clarify the behavior, noting it now applies to any keyblock with a non-empty `outAddress` and still credits `params.KeyBlock_Reward` to the parsed `outAddress`.
- Kept existing safety checks for nil inputs, parent/key block lookups, and keyhash change detection before crediting the reward.

### Testing

- Ran `go test ./consensus/...` which completed successfully. 
- Built the repository with `go build` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f9b17e1c8330be4ddab9eb7af02f)