### PR TITLE
Apply keyblock outAddress reward during consensus finalization

### DIFF
--- a/consensus/colossusX/consensus.go
+++ b/consensus/colossusX/consensus.go
@@ -438,6 +438,7 @@ func (colossusX *colossusX) verifyHeader(chain consensus.ChainHeaderReader, head
 func (colossusX *colossusX) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, totalGas uint64) {
 	// Accumulate any block and uncle rewards and commit the final state root
 	accumulateRewards(chain.Config(), state, header, uncles)
+	ApplyFixedModeKeyblockPowReward(chain, state, header)
 
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 }
@@ -447,6 +448,7 @@ func (colossusX *colossusX) Finalize(chain consensus.ChainHeaderReader, header *
 func (colossusX *colossusX) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
 	// Accumulate any block and uncle rewards and commit the final state root
 	accumulateRewards(chain.Config(), state, header, uncles)
+	ApplyFixedModeKeyblockPowReward(chain, state, header)
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 
 	// Header seems complete, assemble into a block and return


### PR DESCRIPTION
### Motivation

- Keyblock `outAddress` reward was only applied during tx-proposal (`reconfig/txblock.go`) and not during canonical state finalization (`StateProcessor -> engine.Finalize`), causing the reward to be missing from the final chain state.
- Ensure keyblock POW rewards for `outAddress` are applied on the canonical consensus finalization path so balances reflect expected rewards.

### Description

- Call `ApplyFixedModeKeyblockPowReward(chain, state, header)` from the ColossusX `Finalize` implementation in `consensus/colossusX/consensus.go`.
- Call `ApplyFixedModeKeyblockPowReward(chain, state, header)` from `FinalizeAndAssemble` in `consensus/colossusX/consensus.go` for consistency across assembly and finalization flows.
- Left existing tx-proposal usage in `reconfig/txblock.go` intact so rewards continue to be applied there as well.

### Testing

- Attempted to run `go test ./consensus/colossusX`, which failed due to repository layout lacking a `go.mod` and resulting in the error `cannot find main module` (no automated unit test run possible in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6095a96cc8330864e12450dea8775)