### PR TITLE
Apply fixed-mode keyblock PoW reward in colossusX Finalize paths

### DIFF
--- a/consensus/colossusX/consensus.go
+++ b/consensus/colossusX/consensus.go
@@ -438,6 +438,9 @@ func (colossusX *colossusX) verifyHeader(chain consensus.ChainHeaderReader, head
 func (colossusX *colossusX) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, totalGas uint64) {
 	// Accumulate any block and uncle rewards and commit the final state root
 	accumulateRewards(chain.Config(), state, header, uncles)
+	if fullChain, ok := chain.(types.ChainReader); ok {
+		ApplyFixedModeKeyblockPowReward(fullChain, state, header)
+	}
 
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 }
@@ -447,6 +450,9 @@ func (colossusX *colossusX) Finalize(chain consensus.ChainHeaderReader, header *
 func (colossusX *colossusX) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
 	// Accumulate any block and uncle rewards and commit the final state root
 	accumulateRewards(chain.Config(), state, header, uncles)
+	if fullChain, ok := chain.(types.ChainReader); ok {
+		ApplyFixedModeKeyblockPowReward(fullChain, state, header)
+	}
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 
 	// Header seems complete, assemble into a block and return


### PR DESCRIPTION
### Motivation
- Ensure the fixed-mode keyblock PoW reward is applied when finalizing blocks so protocol-specific rewards are included in the final state before committing the header root.

### Description
- Invoke `ApplyFixedModeKeyblockPowReward(fullChain, state, header)` (guarded by `chain.(types.ChainReader)` type assertion) in both `Finalize` and `FinalizeAndAssemble` after `accumulateRewards` so the reward is applied for chains that implement `types.ChainReader`.

### Testing
- Ran unit tests for the consensus package with `go test ./consensus/...` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6095a96cc8330864e12450dea8775)