### PR TITLE
Credit common-node PoW rewards for keyblocks and centralize reward logic

### DIFF
--- a/consensus/colossusX/consensus.go
+++ b/consensus/colossusX/consensus.go
@@ -47,6 +47,7 @@ import (
 var (
 	FrontierBlockReward  = new(big.Int).Mul(big.NewInt(100000), big.NewInt(params.Ether)) // Block reward in wei for successfully mining a block
 	ByzantiumBlockReward = big.NewInt(3e+18)                                              // Block reward in wei for successfully mining a block upward from Byzantium
+	CommonNodePowReward  = new(big.Int).Mul(big.NewInt(100000), big.NewInt(params.Ether)) // Bonus reward in wei for accepted common-node PoW candidate
 
 	errLargeBlockTime    = errors.New("timestamp too big")
 	errZeroBlockTime     = errors.New("timestamp equals parent's")
@@ -438,6 +439,9 @@ func (colossusX *colossusX) verifyHeader(chain consensus.ChainHeaderReader, head
 func (colossusX *colossusX) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, totalGas uint64) {
 	// Accumulate any block and uncle rewards and commit the final state root
 	accumulateRewards(chain.Config(), state, header, uncles)
+	if header.BlockType == types.Key_Block {
+		ApplyKeyblockPowRewardByKeyInfo(state, header.KeyInfo)
+	}
 
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 }
@@ -447,6 +451,9 @@ func (colossusX *colossusX) Finalize(chain consensus.ChainHeaderReader, header *
 func (colossusX *colossusX) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
 	// Accumulate any block and uncle rewards and commit the final state root
 	accumulateRewards(chain.Config(), state, header, uncles)
+	if header.BlockType == types.Key_Block {
+		ApplyKeyblockPowRewardByKeyInfo(state, header.KeyInfo)
+	}
 	header.Root = state.IntermediateRoot(chain.Config().IsEIP158(header.Number))
 
 	// Header seems complete, assemble into a block and return
@@ -527,7 +534,7 @@ func AccumulateRewards(config *params.ChainConfig, state *state.StateDB, header 
 	accumulateRewards(config, state, header, uncles)
 }
 
-// ApplyFixedModeKeyblockPowReward credits KeyBlock_Reward to keyblock outAddress
+// ApplyFixedModeKeyblockPowReward credits CommonNodePowReward to keyblock outAddress
 // when the tx chain switches to a new keyblock (first tx block after keyblock change).
 //
 // NOTE: despite the historical function name, this now applies to any keyblock
@@ -558,7 +565,29 @@ func ApplyFixedModeKeyblockPowReward(bc types.ChainReader, state vm.StateDB, hea
 	if submitter == "" {
 		return
 	}
-	state.AddBalance(common.HexToAddress(submitter), big.NewInt(params.KeyBlock_Reward))
+	state.AddBalance(common.HexToAddress(submitter), new(big.Int).Set(CommonNodePowReward))
+}
+
+// ApplyKeyblockPowRewardByKeyInfo credits CommonNodePowReward to keyblock outAddress
+// at keyblock generation/finalization time.
+func ApplyKeyblockPowRewardByKeyInfo(state vm.StateDB, keyInfo []byte) {
+	if state == nil || len(keyInfo) == 0 {
+		return
+	}
+	keyblock := types.DecodeToKeyBlock(keyInfo)
+	ApplyKeyblockPowReward(state, keyblock)
+}
+
+// ApplyKeyblockPowReward credits CommonNodePowReward to keyblock outAddress.
+func ApplyKeyblockPowReward(state vm.StateDB, keyblock *types.KeyBlock) {
+	if state == nil || keyblock == nil {
+		return
+	}
+	submitter := strings.TrimPrefix(keyblock.OutAddress(0), "*")
+	if submitter == "" {
+		return
+	}
+	state.AddBalance(common.HexToAddress(submitter), new(big.Int).Set(CommonNodePowReward))
 }
 
 func RewardCommites(bc types.ChainReader, state vm.StateDB, header *types.Header, blockReward uint64, beNewVer bool) {

--- a/reconfig/txblock.go
+++ b/reconfig/txblock.go
@@ -83,6 +83,7 @@ func (txS *txService) tryProposalNewKeyBlock(keyblock *types.KeyBlock) ([]byte, 
 	header := work.header
 	// commit state root after all state transitions.
 	colossusX.AccumulateRewards(txS.bc.Config(), work.publicState, header, nil)
+	colossusX.ApplyKeyblockPowReward(work.publicState, keyblock)
 	header.Root = work.publicState.IntermediateRoot(false)
 
 	header.BlockType = types.Key_Block
@@ -130,7 +131,6 @@ func (txS *txService) tryProposalNewBlock(blockType uint8) ([]byte, error) {
 		header.KeyHash = txS.kbc.CurrentBlock().Hash()
 		// commit state root after all state transitions.
 		colossusX.AccumulateRewards(txS.bc.Config(), work.publicState, header, nil)
-		colossusX.ApplyFixedModeKeyblockPowReward(txS.bc, work.publicState, header)
 		header.Root = work.publicState.IntermediateRoot(false)
 		header.BlockType = blockType
 


### PR DESCRIPTION
### Motivation

- Introduce a single configurable reward for common-node PoW candidates and ensure keyblock producers receive that reward at keyblock creation/finalization.
- Consolidate and simplify keyblock PoW reward logic so rewards are applied deterministically from keyblock data rather than relying only on block-proposal side effects.

### Description

- Add `CommonNodePowReward` and replace usages of `params.KeyBlock_Reward` with this shared reward value in `consensus/colossusX/consensus.go`.
- Apply keyblock PoW rewards during block finalization by calling `ApplyKeyblockPowRewardByKeyInfo` in `Finalize` and `FinalizeAndAssemble` when `header.BlockType == types.Key_Block`.
- Add helper functions `ApplyKeyblockPowRewardByKeyInfo` and `ApplyKeyblockPowReward` to decode key info and credit the keyblock `outAddress` with `CommonNodePowReward`.
- Update `ApplyFixedModeKeyblockPowReward` to use `CommonNodePowReward` and keep backward-compatible behavior for the fixed-mode path.
- Ensure the tx service credits keyblock submitter when proposing a keyblock by calling `ApplyKeyblockPowReward` in `reconfig/txblock.go` and remove the fixed-mode call from normal tx block proposal.

### Testing

- Ran `go test ./...` to execute the test suite, which completed successfully.
- Built the codebase with `go build ./...`, which also completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6095a96cc8330864e12450dea8775)