### PR TITLE
Rename key block RPC number fields for eth_getKeyBlockByNumber

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1351,16 +1351,16 @@ func (s *PublicBlockChainAPI) rpcMarshalBlock(ctx context.Context, b *types.Bloc
 func RPCMarshalKeyBlock(b *types.KeyBlock) (map[string]interface{}, error) {
 	head := b.Header() // copies the header once
 	fields := map[string]interface{}{
-		"number":        (*hexutil.Big)(head.Number),
-		"difficulty":    (*hexutil.Big)(head.Difficulty),
-		"hash":          b.Hash(),
-		"parentHash":    head.ParentHash,
-		"nonce":         head.Nonce,
-		"mixDigest":     head.MixDigest,
-		"timestamp":     head.Time,
-		"committeeHash": head.CommitteeHash,
-		"blockType":     head.BlockType,
-		"t_number":      head.T_Number,
+		"keyBlockNumber": (*hexutil.Big)(head.Number),
+		"difficulty":     (*hexutil.Big)(head.Difficulty),
+		"hash":           b.Hash(),
+		"parentHash":     head.ParentHash,
+		"nonce":          head.Nonce,
+		"mixDigest":      head.MixDigest,
+		"timestamp":      head.Time,
+		"committeeHash":  head.CommitteeHash,
+		"blockType":      head.BlockType,
+		"TxBlockNumber":  head.T_Number,
 	}
 
 	fields["inPubKey"] = b.InPubKey()

--- a/internal/jsre/deps/web3.js
+++ b/internal/jsre/deps/web3.js
@@ -3850,8 +3850,10 @@ var outputBlockFormatter = function(block) {
      */
     var outputKeyBlockFormatter = function(block) {
       block.difficulty = utils.toBigNumber(block.difficulty);
-      if(block.number !== null)
-        block.number = utils.toBigNumber(block.number);
+      if(block.keyBlockNumber !== null)
+        block.keyBlockNumber = utils.toBigNumber(block.keyBlockNumber);
+      if(block.TxBlockNumber !== null)
+        block.TxBlockNumber = utils.toBigNumber(block.TxBlockNumber);
       return block;
     };
 


### PR DESCRIPTION
### Motivation
- Align the RPC output for key-block queries with new field naming by replacing the ambiguous `number` and `t_number` keys with clearer names for consumers of `eth_getKeyBlockByNumber`/`eth_getKeyBlockByHash`.

### Description
- Change `RPCMarshalKeyBlock` to emit `keyBlockNumber` instead of `number` and `TxBlockNumber` instead of `t_number` in the returned map from `internal/ethapi/api.go`.
- Update the JS output formatter `outputKeyBlockFormatter` to parse and convert `keyBlockNumber` and `TxBlockNumber` to BigNumber in `internal/jsre/deps/web3.js`.
- Modified files: `internal/ethapi/api.go` and `internal/jsre/deps/web3.js`.

### Testing
- Attempted to run `go test ./internal/ethapi`, but the test run failed because the repository has no Go module configured at the repo root (`go.mod` missing), so automated unit tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7073825148330ab7c8a49b6275e1e)