### PR TITLE
Harden fixed-mode fallback trigger conditions

### DIFF
--- a/reconfig/backend.go
+++ b/reconfig/backend.go
@@ -66,6 +66,7 @@ type serviceI interface {
 	setNextLeader(isDone bool)
 	sendNewViewMsg(curN uint64)
 	LeaderAckTime() time.Time
+	HotstuffProgressTime() time.Time
 	ResetLeaderAckTime()
 	SwitchOK() bool
 }
@@ -143,7 +144,7 @@ func (backend *ReconfigBackend) Stop() error {
 	return nil
 }
 
-//------------------------------------------------------------------
+// ------------------------------------------------------------------
 func (backend *ReconfigBackend) MinerStart(config *common.NodeConfig) error {
 	backend.service.start(config)
 	log.Info("reconfig start")
@@ -156,7 +157,7 @@ func (backend *ReconfigBackend) MinerStop() error {
 	return nil
 }
 
-//ReconfigIsRunning call by api
+// ReconfigIsRunning call by api
 func (backend *ReconfigBackend) ServiceIsRunning() bool {
 	return backend.service.isRunning()
 }

--- a/reconfig/paceMaker.go
+++ b/reconfig/paceMaker.go
@@ -41,6 +41,8 @@ type paceMakerTimer struct {
 	txPool        *core.TxPool
 	candidatepool *core.CandidatePool
 	retryNumber   int
+	ackMissCount  int
+	lastAckMissAt time.Time
 	config        *params.ChainConfig
 	kbc           *core.KeyBlockChain
 	mu            sync.Mutex
@@ -104,6 +106,8 @@ func (t *paceMakerTimer) stop() error {
 	defer t.mu.Unlock()
 	t.beStop = true
 	t.retryNumber = 0
+	t.ackMissCount = 0
+	t.lastAckMissAt = time.Time{}
 	t.startTime = maxPaceMakerTime
 	return nil
 }
@@ -121,6 +125,23 @@ func (t *paceMakerTimer) get() (time.Time, bool, bool, int) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.startTime, t.beStop, t.beClose, t.retryNumber
+}
+
+func (t *paceMakerTimer) recordAckMiss(now time.Time) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.lastAckMissAt.IsZero() || now.Sub(t.lastAckMissAt) >= params.AckTimeout {
+		t.ackMissCount++
+		t.lastAckMissAt = now
+	}
+	return t.ackMissCount
+}
+
+func (t *paceMakerTimer) resetAckMissCount() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.ackMissCount = 0
+	t.lastAckMissAt = time.Time{}
 }
 
 // Loop for status action
@@ -152,12 +173,27 @@ func (t *paceMakerTimer) loopTimer() {
 
 		diff := now.Sub(startTime)
 		leaderSilentFor := now.Sub(t.service.LeaderAckTime())
+		progressSilentFor := now.Sub(t.service.HotstuffProgressTime())
+		fixedMode := t.config != nil && (t.config.FixedLeader || t.config.FixedCommittee)
 		if leaderSilentFor > params.AckTimeout && bftview.IamMember() >= 0 {
-			log.Warn("paceMakerTimer Viewchange AckTimeout")
+			if progressSilentFor <= params.AckTimeout {
+				t.resetAckMissCount()
+				continue
+			}
+			if fixedMode {
+				missCount := t.recordAckMiss(now)
+				if missCount < 3 {
+					log.Warn("paceMakerTimer fixed mode suppress fallback", "ackMissCount", missCount, "ackSilentFor", leaderSilentFor, "progressSilentFor", progressSilentFor)
+					continue
+				}
+			}
+			log.Warn("paceMakerTimer Viewchange AckTimeout", "ackSilentFor", leaderSilentFor, "progressSilentFor", progressSilentFor)
 			t.setNextLeader(false)
 			t.service.ResetLeaderAckTime()
+			t.resetAckMissCount()
 		} else if diff > params.PaceMakerTimeout /**time.Duration(retryNumber+1)*/ && bftview.IamMember() >= 0 &&
-			!(t.config != nil && (t.config.FixedLeader || t.config.FixedCommittee)) { //timeout
+			!fixedMode { //timeout
+			t.resetAckMissCount()
 			log.Warn("paceMakerTimer Viewchange PaceMakerTimeout Event is coming", "retryNumber", retryNumber)
 			/*
 				switchLen := bftview.GetServerCommitteeLen()/2 + 1
@@ -169,6 +205,8 @@ func (t *paceMakerTimer) loopTimer() {
 			*/
 			t.setNextLeader(false)
 			t.retryNumber++
+		} else if leaderSilentFor <= params.AckTimeout || progressSilentFor <= params.AckTimeout {
+			t.resetAckMissCount()
 		}
 	}
 }

--- a/reconfig/service.go
+++ b/reconfig/service.go
@@ -117,6 +117,11 @@ type Service struct {
 	lastCadenceWakeup  time.Time
 	tryProposeQueuedAt int64
 	pacetMakerTimer    *paceMakerTimer
+	muHotstuffProgress sync.Mutex
+	hotstuffProgressAt time.Time
+	lastProgressN      uint64
+	lastProgressViewID uint64
+	lastProgressRank   uint8
 
 	hotstuffMsgQ *common.Queue
 	feed1        event.Feed
@@ -141,6 +146,7 @@ func newService(sName, sIp string, chainConfig *params.ChainConfig, backend *Rec
 	s.msgCh1 = make(chan committeeMsg, 10)
 	s.msgSub1 = s.feed1.Subscribe(s.msgCh1)
 	s.hotstuffMsgQ = common.QueueNew()
+	s.hotstuffProgressAt = time.Now()
 
 	s.protocolMng = hotstuff.NewHotstuffProtocolManager(s, nil, nil)
 	s.pacetMakerTimer = newPaceMakerTimer(chainConfig, s, backend)
@@ -560,6 +566,7 @@ func (s *Service) handleHotStuffMsg() {
 		}
 		msg := data.(*hotstuffMsg)
 		msgCode := msg.hMsg.Code
+		s.observeHotstuffProgress(msg.hMsg)
 		if msgCode == hotstuff.MsgTryPropose {
 			atomic.StoreInt64(&s.tryProposeQueuedAt, 0)
 		}
@@ -591,6 +598,38 @@ func (s *Service) handleHotStuffMsg() {
 			}(curN)
 		}
 	}
+}
+
+func (s *Service) observeHotstuffProgress(msg *hotstuff.HotstuffMessage) {
+	if msg == nil {
+		return
+	}
+	rank := uint8(0)
+	switch msg.Code {
+	case hotstuff.MsgPrepare:
+		rank = 1
+	case hotstuff.MsgDecide:
+		rank = 2
+	default:
+		return
+	}
+
+	s.muHotstuffProgress.Lock()
+	defer s.muHotstuffProgress.Unlock()
+	if msg.Number > s.lastProgressN ||
+		(msg.Number == s.lastProgressN && msg.ViewId > s.lastProgressViewID) ||
+		(msg.Number == s.lastProgressN && msg.ViewId == s.lastProgressViewID && rank > s.lastProgressRank) {
+		s.lastProgressN = msg.Number
+		s.lastProgressViewID = msg.ViewId
+		s.lastProgressRank = rank
+		s.hotstuffProgressAt = time.Now()
+	}
+}
+
+func (s *Service) HotstuffProgressTime() time.Time {
+	s.muHotstuffProgress.Lock()
+	defer s.muHotstuffProgress.Unlock()
+	return s.hotstuffProgressAt
 }
 
 // -------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Prevent spurious leader fallback in fixed-mode where a single `AckTimeout` or transient missing ACKs could trigger `setNextLeader(false)` even while HotStuff is making progress.
- Treat HotStuff progress (forward movement on `MsgPrepare`/`MsgDecide`) as a liveness signal in addition to heartbeat ACKs.

### Description
- Add HotStuff progress tracking to `Service` by recording the latest monotonic progress tuple `(Number, ViewId, phase)` and the last progress timestamp, and expose it via `HotstuffProgressTime()`.
- Extend `serviceI` with `HotstuffProgressTime()` so pacemaker can observe HotStuff progress time.
- In `paceMakerTimer`, add `ackMissCount` and `lastAckMissAt` to track consecutive ACK misses and helper methods `recordAckMiss`/`resetAckMissCount` to manage the counter.
- Change pacemaker fallback logic to require both ACK silence > `AckTimeout` and HotStuff progress silence > `AckTimeout` before proceeding; in fixed mode require 3 spaced ACK-misses (each >= `AckTimeout`) before calling `setNextLeader(false)`, and reset the miss counter when ACK or HotStuff progress is healthy.

### Testing
- Ran `gofmt` over modified files (`reconfig/service.go`, `reconfig/paceMaker.go`, `reconfig/backend.go`) successfully.
- Attempted `go test ./reconfig/...` and `go test ./...`, but the workspace is not configured as a Go module so tests could not be executed (module resolution error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71ef703bc833081b31e0312691c73)