### PR TITLE
Fix hotstuff progress view ID comparisons in reconfig service

### DIFF
--- a/reconfig/service.go
+++ b/reconfig/service.go
@@ -17,6 +17,7 @@
 package reconfig
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"strings"
@@ -120,7 +121,7 @@ type Service struct {
 	muHotstuffProgress sync.Mutex
 	hotstuffProgressAt time.Time
 	lastProgressN      uint64
-	lastProgressViewID uint64
+	lastProgressViewID common.Hash
 	lastProgressRank   uint8
 
 	hotstuffMsgQ *common.Queue
@@ -616,9 +617,10 @@ func (s *Service) observeHotstuffProgress(msg *hotstuff.HotstuffMessage) {
 
 	s.muHotstuffProgress.Lock()
 	defer s.muHotstuffProgress.Unlock()
+	viewCompare := bytes.Compare(msg.ViewId[:], s.lastProgressViewID[:])
 	if msg.Number > s.lastProgressN ||
-		(msg.Number == s.lastProgressN && msg.ViewId > s.lastProgressViewID) ||
-		(msg.Number == s.lastProgressN && msg.ViewId == s.lastProgressViewID && rank > s.lastProgressRank) {
+		(msg.Number == s.lastProgressN && viewCompare > 0) ||
+		(msg.Number == s.lastProgressN && viewCompare == 0 && rank > s.lastProgressRank) {
 		s.lastProgressN = msg.Number
 		s.lastProgressViewID = msg.ViewId
 		s.lastProgressRank = rank


### PR DESCRIPTION
### Motivation
- The hotstuff progress logic compared `HotstuffMessage.ViewId` (a `common.Hash`) against a `uint64`, causing compilation errors and incorrect view ordering.

### Description
- Change `lastProgressViewID` from `uint64` to `common.Hash` in `reconfig/service.go` to match `HotstuffMessage.ViewId`.
- Import `bytes` and replace direct numeric/hash comparisons with `bytes.Compare(msg.ViewId[:], s.lastProgressViewID[:])` to preserve ordering by number, view ID, and rank.

### Testing
- Ran `go test ./reconfig/...`, which failed due to the repository not being in a recognized Go module/GOPATH layout in this environment so packages could not be resolved.
- Ran `make cypher`, which also failed here because `go.mod`/module dependencies could not be located in this container setup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72095cf688330905bd004223d746c)