### PR TITLE
Add nil guard before reading HotStuff message code

### DIFF
--- a/reconfig/service.go
+++ b/reconfig/service.go
@@ -566,6 +566,10 @@ func (s *Service) handleHotStuffMsg() {
 			continue
 		}
 		msg := data.(*hotstuffMsg)
+		if msg == nil || msg.hMsg == nil {
+			log.Warn("handleHotStuffMsg received nil message")
+			continue
+		}
 		msgCode := msg.hMsg.Code
 		s.observeHotstuffProgress(msg.hMsg)
 		if msgCode == hotstuff.MsgTryPropose {


### PR DESCRIPTION
### Motivation
- Prevent a potential nil-pointer panic in `handleHotStuffMsg` by ensuring the dequeued wrapper and its `hMsg` are non-nil before accessing `msg.hMsg.Code`.

### Description
- In `reconfig/service.go` inside `handleHotStuffMsg`, after `data := s.hotstuffMsgQ.PopFront()` and the type assertion, add `if msg == nil || msg.hMsg == nil { log.Warn("handleHotStuffMsg received nil message"); continue }` to skip and log nil entries.

### Testing
- Ran `go test ./reconfig -run TestDoesNotExist`, which failed to run due to repository not being configured as a Go module (`cannot find main module`). No repository unit tests were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a6197a108330a47a8baa1260f128)