### PR TITLE
Fix tx MarshalJSON to preserve hex RPC field formats

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -160,30 +160,30 @@ func (tx *Transaction) DecodeRLP(s *rlp.Stream) error {
 // MarshalJSON encodes the web3 RPC transaction format.
 func (tx *Transaction) MarshalJSON() ([]byte, error) {
 	type txJSON struct {
-		AccountNonce uint64          `json:"nonce"`
-		Price        *big.Int        `json:"gasPrice"`
-		GasLimit     uint64          `json:"gas"`
+		AccountNonce hexutil.Uint64  `json:"nonce"`
+		Price        *hexutil.Big    `json:"gasPrice"`
+		GasLimit     hexutil.Uint64  `json:"gas"`
 		Recipient    *common.Address `json:"to"`
-		Amount       *big.Int        `json:"value"`
-		Payload      []byte          `json:"input"`
+		Amount       *hexutil.Big    `json:"value"`
+		Payload      hexutil.Bytes   `json:"input"`
 		RouteHint    TxRouteHint     `json:"routeHint,omitempty"`
-		V            *big.Int        `json:"v"`
-		R            *big.Int        `json:"r"`
-		S            *big.Int        `json:"s"`
+		V            *hexutil.Big    `json:"v"`
+		R            *hexutil.Big    `json:"r"`
+		S            *hexutil.Big    `json:"s"`
 		Hash         *common.Hash    `json:"hash"`
 	}
 	hash := tx.Hash()
 	return json.Marshal(txJSON{
-		AccountNonce: tx.data.AccountNonce,
-		Price:        tx.data.Price,
-		GasLimit:     tx.data.GasLimit,
+		AccountNonce: hexutil.Uint64(tx.data.AccountNonce),
+		Price:        (*hexutil.Big)(tx.data.Price),
+		GasLimit:     hexutil.Uint64(tx.data.GasLimit),
 		Recipient:    tx.data.Recipient,
-		Amount:       tx.data.Amount,
+		Amount:       (*hexutil.Big)(tx.data.Amount),
 		Payload:      tx.data.Payload,
 		RouteHint:    tx.routeHint,
-		V:            tx.data.V,
-		R:            tx.data.R,
-		S:            tx.data.S,
+		V:            (*hexutil.Big)(tx.data.V),
+		R:            (*hexutil.Big)(tx.data.R),
+		S:            (*hexutil.Big)(tx.data.S),
 		Hash:         &hash,
 	})
 }


### PR DESCRIPTION
### Motivation
- `Transaction.MarshalJSON` emitted raw Go numeric/byte types for RPC fields while `txdata.UnmarshalJSON` expects hex-encoded values, causing JSON round-trip decoding to fail.
- The failing case was exposed by `TestRouteHintJSONRoundTrip`, which round-trips a transaction through `MarshalJSON` → `UnmarshalJSON` and asserted equality.

### Description
- Change `Transaction.MarshalJSON` to use `hexutil` wrapper types (`hexutil.Uint64`, `*hexutil.Big`, `hexutil.Bytes`) for `nonce`, `gasPrice`, `gas`, `value`, `input`, and `v/r/s` so JSON emits the expected hex formats.
- Convert the transaction's internal `tx.data` values into the corresponding `hexutil` types when building the JSON payload.
- Preserve the non-consensus `routeHint` field and the emitted `hash` in the output.

### Testing
- Ran `GOPATH=/workspace GO111MODULE=off go test ./core/types` and the package tests passed.
- Ran `GOPATH=/workspace GO111MODULE=off go test ./core/types -run TestRouteHintJSONRoundTrip -v` and the `TestRouteHintJSONRoundTrip` test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e80d6bcd1c83309871b1046fd42514)