### PR TITLE
Improve validation and robustness in math, prque, forkid, p2p and rlp; add targeted tests

### DIFF
--- a/common/math/big.go
+++ b/common/math/big.go
@@ -73,6 +73,9 @@ func ParseBig256(s string) (*big.Int, bool) {
 	if s == "" {
 		return new(big.Int), true
 	}
+	if s[0] == '+' || s[0] == '-' {
+		return nil, false
+	}
 	var bigint *big.Int
 	var ok bool
 	if len(s) >= 2 && (s[:2] == "0x" || s[:2] == "0X") {
@@ -80,7 +83,7 @@ func ParseBig256(s string) (*big.Int, bool) {
 	} else {
 		bigint, ok = new(big.Int).SetString(s, 10)
 	}
-	if ok && bigint.BitLen() > 256 {
+	if ok && (bigint.Sign() < 0 || bigint.BitLen() > 256) {
 		bigint, ok = nil, false
 	}
 	return bigint, ok
@@ -160,7 +163,7 @@ func bigEndianByteAt(bigint *big.Int, n int) byte {
 // n==0 returns the MSB
 // Example: bigint '5', padlength 32, n=31 => 5
 func Byte(bigint *big.Int, padlength, n int) byte {
-	if n >= padlength {
+	if n < 0 || n >= padlength {
 		return byte(0)
 	}
 	return bigEndianByteAt(bigint, padlength-1-n)
@@ -211,13 +214,14 @@ func S256(x *big.Int) *big.Int {
 // Courtesy @karalabe and @chfast
 func Exp(base, exponent *big.Int) *big.Int {
 	result := big.NewInt(1)
+	baseCopy := new(big.Int).Set(base)
 
 	for _, word := range exponent.Bits() {
 		for i := 0; i < wordBits; i++ {
 			if word&1 == 1 {
-				U256(result.Mul(result, base))
+				U256(result.Mul(result, baseCopy))
 			}
-			U256(base.Mul(base, base))
+			U256(baseCopy.Mul(baseCopy, baseCopy))
 			word >>= 1
 		}
 	}

--- a/common/math/big_test.go
+++ b/common/math/big_test.go
@@ -45,6 +45,9 @@ func TestHexOrDecimal256(t *testing.T) {
 		// Invalid syntax:
 		{"abcdef", nil, false},
 		{"0xgg", nil, false},
+		{"-1", nil, false},
+		{"-0", nil, false},
+		{"+1", nil, false},
 		// Larger than 256 bits:
 		{"115792089237316195423570985008687907853269984665640564039457584007913129639936", nil, false},
 	}
@@ -58,6 +61,18 @@ func TestHexOrDecimal256(t *testing.T) {
 		if test.num != nil && (*big.Int)(&num).Cmp(test.num) != 0 {
 			t.Errorf("ParseBig(%q) -> %d, want %d", test.input, (*big.Int)(&num), test.num)
 		}
+	}
+}
+
+func TestParseBig256RejectsNegative(t *testing.T) {
+	if _, ok := ParseBig256("-1"); ok {
+		t.Fatal("expected ParseBig256 to reject negative values")
+	}
+	if _, ok := ParseBig256("-0"); ok {
+		t.Fatal("expected ParseBig256 to reject sign-prefixed zero values")
+	}
+	if _, ok := ParseBig256("+1"); ok {
+		t.Fatal("expected ParseBig256 to reject plus-prefixed values")
 	}
 }
 
@@ -229,6 +244,7 @@ func TestBigEndianByteAt(t *testing.T) {
 		exp byte
 	}{
 		{"00", 0, 0x00},
+		{"00", -1, 0x00},
 		{"01", 1, 0x00},
 		{"00", 1, 0x00},
 		{"01", 0, 0x01},
@@ -254,6 +270,7 @@ func TestLittleEndianByteAt(t *testing.T) {
 		exp byte
 	}{
 		{"00", 0, 0x00},
+		{"00", -1, 0x00},
 		{"01", 1, 0x00},
 		{"00", 1, 0x00},
 		{"01", 0, 0x00},
@@ -278,6 +295,18 @@ func TestLittleEndianByteAt(t *testing.T) {
 			t.Fatalf("Expected  [%v] %v:th byte to be %v, was %v.", test.x, test.y, test.exp, actual)
 		}
 
+	}
+}
+
+func TestExpDoesNotMutateBase(t *testing.T) {
+	base := big.NewInt(3)
+	exponent := big.NewInt(5)
+	originalBase := new(big.Int).Set(base)
+
+	_ = Exp(base, exponent)
+
+	if base.Cmp(originalBase) != 0 {
+		t.Fatalf("Exp mutated base: have %v, want %v", base, originalBase)
 	}
 }
 

--- a/common/math/integer.go
+++ b/common/math/integer.go
@@ -65,6 +65,9 @@ func ParseUint64(s string) (uint64, bool) {
 	if s == "" {
 		return 0, true
 	}
+	if s[0] == '+' || s[0] == '-' {
+		return 0, false
+	}
 	if len(s) >= 2 && (s[:2] == "0x" || s[:2] == "0X") {
 		v, err := strconv.ParseUint(s[2:], 16, 64)
 		return v, err == nil
@@ -102,18 +105,16 @@ func SafeMul(x, y uint64) (uint64, bool) {
 
 // GetRandIntArray returns int array with no repeat
 func GetRandIntArray(max int, num int) map[int]bool {
-	if num > max-1 {
-		num = max - 1
-	}
 	a := make(map[int]bool)
-	rand.Seed(time.Now().UnixNano())
-	maxLoop := num * 10
-	for i := 0; i < maxLoop; i++ {
-		a[rand.Intn(max)] = true
-		if len(a) == num {
-			break
-		}
+	if max <= 0 || num <= 0 {
+		return a
 	}
-
+	if num > max {
+		num = max
+	}
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for _, v := range r.Perm(max)[:num] {
+		a[v] = true
+	}
 	return a
 }

--- a/common/math/integer_test.go
+++ b/common/math/integer_test.go
@@ -84,6 +84,8 @@ func TestHexOrDecimal64(t *testing.T) {
 		// Invalid syntax:
 		{"abcdef", 0, false},
 		{"0xgg", 0, false},
+		{"+1", 0, false},
+		{"-0", 0, false},
 		// Doesn't fit into 64 bits:
 		{"18446744073709551617", 0, false},
 	}
@@ -113,4 +115,26 @@ func TestMustParseUint64Panic(t *testing.T) {
 		}
 	}()
 	MustParseUint64("ggg")
+}
+
+func TestGetRandIntArrayBounds(t *testing.T) {
+	if got := GetRandIntArray(0, 3); len(got) != 0 {
+		t.Fatalf("expected empty result for max=0, got len=%d", len(got))
+	}
+	if got := GetRandIntArray(5, 0); len(got) != 0 {
+		t.Fatalf("expected empty result for num=0, got len=%d", len(got))
+	}
+}
+
+func TestGetRandIntArrayCapsToMax(t *testing.T) {
+	max := 5
+	got := GetRandIntArray(max, max+10)
+	if len(got) != max {
+		t.Fatalf("expected len=%d, got %d", max, len(got))
+	}
+	for v := range got {
+		if v < 0 || v >= max {
+			t.Fatalf("out-of-range value %d", v)
+		}
+	}
 }

--- a/common/prque/lazyqueue.go
+++ b/common/prque/lazyqueue.go
@@ -89,7 +89,9 @@ func (q *LazyQueue) Push(data interface{}) {
 
 // Update updates the upper priority estimate for the item with the given queue index
 func (q *LazyQueue) Update(index int) {
-	q.Push(q.Remove(index))
+	if item := q.Remove(index); item != nil {
+		q.Push(item)
+	}
 }
 
 // Pop removes and returns the item with the greatest actual priority
@@ -154,7 +156,11 @@ func (q *LazyQueue) Remove(index int) interface{} {
 	if index < 0 {
 		return nil
 	}
-	return heap.Remove(q.queue[index&1^q.indexOffset], index>>1).(*item).value
+	queue := q.queue[index&1^q.indexOffset]
+	if (index >> 1) >= queue.Len() {
+		return nil
+	}
+	return heap.Remove(queue, index>>1).(*item).value
 }
 
 // Empty checks whether the priority queue is empty.
@@ -169,6 +175,9 @@ func (q *LazyQueue) Size() int {
 
 // setIndex0 translates internal queue item index to the virtual index space of LazyQueue
 func (q *LazyQueue) setIndex0(data interface{}, index int) {
+	if q.setIndex == nil {
+		return
+	}
 	if index == -1 {
 		q.setIndex(data, -1)
 	} else {
@@ -178,5 +187,8 @@ func (q *LazyQueue) setIndex0(data interface{}, index int) {
 
 // setIndex1 translates internal queue item index to the virtual index space of LazyQueue
 func (q *LazyQueue) setIndex1(data interface{}, index int) {
+	if q.setIndex == nil {
+		return
+	}
 	q.setIndex(data, index+index+1)
 }

--- a/common/prque/lazyqueue_test.go
+++ b/common/prque/lazyqueue_test.go
@@ -122,3 +122,43 @@ func TestLazyQueue(t *testing.T) {
 
 	close(stopCh)
 }
+
+func TestLazyQueueRemoveOutOfRange(t *testing.T) {
+	clock := &mclock.Simulated{}
+	q := NewLazyQueue(testSetIndex, testPriority, testMaxPriority, clock, testQueueRefresh)
+
+	item := &lazyItem{p: 1, index: -1}
+	q.Push(item)
+
+	if got := q.Remove(100); got != nil {
+		t.Fatalf("expected nil for out-of-range remove, got %#v", got)
+	}
+	if q.Size() != 1 {
+		t.Fatalf("queue size changed after out-of-range remove, got %d", q.Size())
+	}
+}
+
+func TestLazyQueueUpdateOutOfRange(t *testing.T) {
+	clock := &mclock.Simulated{}
+	q := NewLazyQueue(testSetIndex, testPriority, testMaxPriority, clock, testQueueRefresh)
+
+	item := &lazyItem{p: 1, index: -1}
+	q.Push(item)
+	q.Update(100) // must be a no-op
+
+	if q.Size() != 1 {
+		t.Fatalf("queue size changed after out-of-range update, got %d", q.Size())
+	}
+}
+
+func TestLazyQueueNilSetIndexCallback(t *testing.T) {
+	clock := &mclock.Simulated{}
+	q := NewLazyQueue(nil, testPriority, testMaxPriority, clock, testQueueRefresh)
+
+	item := &lazyItem{p: 7}
+	q.Push(item)
+
+	if got := q.PopItem(); got != item {
+		t.Fatalf("unexpected popped item: have %#v, want %#v", got, item)
+	}
+}

--- a/common/prque/prque.go
+++ b/common/prque/prque.go
@@ -33,11 +33,17 @@ func New(setIndex SetIndexCallback) *Prque {
 
 // Pushes a value with a given priority into the queue, expanding if necessary.
 func (p *Prque) Push(data interface{}, priority int64) {
+	if p.cont == nil {
+		p.cont = newSstack(nil)
+	}
 	heap.Push(p.cont, &item{data, priority})
 }
 
 // Peek returns the value with the greates priority but does not pop it off.
 func (p *Prque) Peek() (interface{}, int64) {
+	if p.cont == nil || p.cont.Len() == 0 {
+		return nil, 0
+	}
 	item := p.cont.blocks[0][0]
 	return item.value, item.priority
 }
@@ -45,34 +51,45 @@ func (p *Prque) Peek() (interface{}, int64) {
 // Pops the value with the greates priority off the stack and returns it.
 // Currently no shrinking is done.
 func (p *Prque) Pop() (interface{}, int64) {
+	if p.cont == nil || p.cont.Len() == 0 {
+		return nil, 0
+	}
 	item := heap.Pop(p.cont).(*item)
 	return item.value, item.priority
 }
 
 // Pops only the item from the queue, dropping the associated priority value.
 func (p *Prque) PopItem() interface{} {
-	return heap.Pop(p.cont).(*item).value
+	item, _ := p.Pop()
+	return item
 }
 
 // Remove removes the element with the given index.
 func (p *Prque) Remove(i int) interface{} {
-	if i < 0 {
+	if p.cont == nil || i < 0 || i >= p.cont.Len() {
 		return nil
 	}
-	return heap.Remove(p.cont, i)
+	return heap.Remove(p.cont, i).(*item).value
 }
 
 // Checks whether the priority queue is empty.
 func (p *Prque) Empty() bool {
-	return p.cont.Len() == 0
+	return p.cont == nil || p.cont.Len() == 0
 }
 
 // Returns the number of element in the priority queue.
 func (p *Prque) Size() int {
+	if p.cont == nil {
+		return 0
+	}
 	return p.cont.Len()
 }
 
 // Clears the contents of the priority queue.
 func (p *Prque) Reset() {
+	if p.cont == nil {
+		*p = *New(nil)
+		return
+	}
 	*p = *New(p.cont.setIndex)
 }

--- a/common/prque/prque_test.go
+++ b/common/prque/prque_test.go
@@ -1,0 +1,83 @@
+package prque
+
+import "testing"
+
+func TestRemoveReturnsStoredValue(t *testing.T) {
+	q := New(nil)
+	q.Push("low", 1)
+	q.Push("high", 10)
+
+	removed := q.Remove(0)
+	if removed != "high" {
+		t.Fatalf("expected removed value %q, got %#v", "high", removed)
+	}
+	if q.Size() != 1 {
+		t.Fatalf("expected size 1 after remove, got %d", q.Size())
+	}
+	item, _ := q.Pop()
+	if item != "low" {
+		t.Fatalf("expected remaining value %q, got %#v", "low", item)
+	}
+}
+
+func TestRemoveNegativeIndex(t *testing.T) {
+	q := New(nil)
+	q.Push("x", 1)
+	if got := q.Remove(-1); got != nil {
+		t.Fatalf("expected nil for negative index, got %#v", got)
+	}
+	if q.Size() != 1 {
+		t.Fatalf("queue size changed after negative remove, got %d", q.Size())
+	}
+}
+
+func TestRemoveOutOfRangeIndex(t *testing.T) {
+	q := New(nil)
+	q.Push("x", 1)
+	if got := q.Remove(1); got != nil {
+		t.Fatalf("expected nil for out-of-range index, got %#v", got)
+	}
+	if q.Size() != 1 {
+		t.Fatalf("queue size changed after out-of-range remove, got %d", q.Size())
+	}
+}
+
+func TestPeekEmptyQueue(t *testing.T) {
+	q := New(nil)
+	item, priority := q.Peek()
+	if item != nil || priority != 0 {
+		t.Fatalf("expected nil/0 from empty Peek, got %#v/%d", item, priority)
+	}
+}
+
+func TestPopEmptyQueue(t *testing.T) {
+	q := New(nil)
+	item, priority := q.Pop()
+	if item != nil || priority != 0 {
+		t.Fatalf("expected nil/0 from empty Pop, got %#v/%d", item, priority)
+	}
+	if got := q.PopItem(); got != nil {
+		t.Fatalf("expected nil from empty PopItem, got %#v", got)
+	}
+}
+
+func TestZeroValuePrque(t *testing.T) {
+	var q Prque
+	if !q.Empty() || q.Size() != 0 {
+		t.Fatal("zero-value queue should be empty")
+	}
+	if item, pri := q.Peek(); item != nil || pri != 0 {
+		t.Fatalf("unexpected zero-value peek result: %#v/%d", item, pri)
+	}
+	q.Push("x", 1)
+	if q.Size() != 1 {
+		t.Fatalf("expected size 1 after push, got %d", q.Size())
+	}
+	if item, pri := q.Pop(); item != "x" || pri != 1 {
+		t.Fatalf("unexpected pop result: %#v/%d", item, pri)
+	}
+	q.Reset()
+	if !q.Empty() || q.Size() != 0 {
+		t.Fatal("queue should be empty after reset")
+	}
+}

--- a/core/forkid/forkid.go
+++ b/core/forkid/forkid.go
@@ -215,6 +215,9 @@ func checksumToBytes(hash uint32) [4]byte {
 
 // gatherForks gathers all the known forks and creates a sorted list out of them.
 func gatherForks(config *params.ChainConfig) []uint64 {
+	if config == nil {
+		return nil
+	}
 	// Gather all the fork block numbers via reflection
 	kind := reflect.TypeOf(params.ChainConfig{})
 	conf := reflect.ValueOf(config).Elem()
@@ -231,7 +234,7 @@ func gatherForks(config *params.ChainConfig) []uint64 {
 		}
 		// Extract the fork rule block number and aggregate it
 		rule := conf.Field(i).Interface().(*big.Int)
-		if rule != nil {
+		if rule != nil && rule.Sign() > 0 {
 			forks = append(forks, rule.Uint64())
 		}
 	}
@@ -249,10 +252,6 @@ func gatherForks(config *params.ChainConfig) []uint64 {
 			forks = append(forks[:i], forks[i+1:]...)
 			i--
 		}
-	}
-	// Skip any forks in block 0, that's the genesis ruleset
-	if len(forks) > 0 && forks[0] == 0 {
-		forks = forks[1:]
 	}
 	return forks
 }

--- a/core/forkid/forkid_test.go
+++ b/core/forkid/forkid_test.go
@@ -18,7 +18,9 @@ package forkid
 
 import (
 	"bytes"
+	"hash/crc32"
 	"math"
+	"math/big"
 	"testing"
 
 	"github.com/cypherium/cypher/common"
@@ -223,5 +225,35 @@ func TestEncoding(t *testing.T) {
 		if !bytes.Equal(have, tt.want) {
 			t.Errorf("test %d: RLP mismatch: have %x, want %x", i, have, tt.want)
 		}
+	}
+}
+
+func TestGatherForksIgnoresNonPositiveBlocks(t *testing.T) {
+	config := &params.ChainConfig{
+		ChainID:         big.NewInt(1),
+		HomesteadBlock:  big.NewInt(-1),
+		DAOForkBlock:    big.NewInt(0),
+		EIP150Block:     big.NewInt(8),
+		PetersburgBlock: big.NewInt(8), // duplicate values should be deduplicated
+	}
+	forks := gatherForks(config)
+	if len(forks) != 1 || forks[0] != 8 {
+		t.Fatalf("unexpected forks: %v", forks)
+	}
+}
+
+func TestGatherForksNilConfig(t *testing.T) {
+	if forks := gatherForks(nil); len(forks) != 0 {
+		t.Fatalf("unexpected forks for nil config: %v", forks)
+	}
+}
+
+func TestNewIDWithNilConfig(t *testing.T) {
+	genesis := common.HexToHash("0x01")
+	id := newID(nil, genesis, 12345)
+
+	want := ID{Hash: checksumToBytes(crc32.ChecksumIEEE(genesis[:])), Next: 0}
+	if id != want {
+		t.Fatalf("unexpected fork id: have %v, want %v", id, want)
 	}
 }

--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -72,7 +72,10 @@ const (
 
 // errPlainMessageTooLarge is returned if a decompressed message length exceeds
 // the allowed 24 bits (i.e. length >= 16MB).
-var errPlainMessageTooLarge = errors.New("message length >= 16MB")
+var (
+	errPlainMessageTooLarge = errors.New("message length >= 16MB")
+	errMessageFrameTooLarge = errors.New("message size overflows uint24")
+)
 
 // rlpx is the transport protocol used by actual (non-test) connections.
 // It wraps the frame encoder with locks and read/write deadlines.
@@ -601,10 +604,11 @@ func (rw *rlpxFrameRW) WriteMsg(msg Msg) error {
 	}
 	// write header
 	headbuf := make([]byte, 32)
-	fsize := uint32(len(ptype)) + msg.Size
-	if fsize > maxUint24 {
-		return errors.New("message size overflows uint24")
+	fsize64 := uint64(len(ptype)) + uint64(msg.Size)
+	if fsize64 > maxUint24 {
+		return errMessageFrameTooLarge
 	}
+	fsize := uint32(fsize64)
 	putInt24(fsize, headbuf) // TODO: check overflow
 	copy(headbuf[3:], zeroHeader)
 	rw.enc.XORKeyStream(headbuf[:16], headbuf[:16]) // first half is now encrypted

--- a/p2p/rlpx_test.go
+++ b/p2p/rlpx_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net"
 	"reflect"
 	"strings"
@@ -372,6 +373,23 @@ func TestRLPXFrameRW(t *testing.T) {
 		if !bytes.Equal(payload, wantPayload) {
 			t.Fatalf("msg payload mismatch:\ngot  %x\nwant %x", payload, wantPayload)
 		}
+	}
+}
+
+func TestRLPXFrameRWRejectsFrameSizeOverflow(t *testing.T) {
+	rw := newRLPXFrameRW(new(bytes.Buffer), secrets{
+		AES:        crypto.Keccak256(),
+		MAC:        crypto.Keccak256(),
+		IngressMAC: fakeHash(make([]byte, 32)),
+		EgressMAC:  fakeHash(make([]byte, 32)),
+	})
+	msg := Msg{
+		Code:    1,
+		Size:    math.MaxUint32,
+		Payload: bytes.NewReader(nil),
+	}
+	if err := rw.WriteMsg(msg); err != errMessageFrameTooLarge {
+		t.Fatalf("expected %v, got %v", errMessageFrameTooLarge, err)
 	}
 }
 

--- a/rlp/iterator.go
+++ b/rlp/iterator.go
@@ -41,12 +41,19 @@ func NewListIterator(data RawValue) (*listIterator, error) {
 // Next forwards the iterator one step, returns true if it was not at end yet
 func (it *listIterator) Next() bool {
 	if len(it.data) == 0 {
+		it.next = nil
+		it.err = nil
 		return false
 	}
 	_, t, c, err := readKind(it.data)
+	if err != nil {
+		it.next = nil
+		it.err = err
+		return false
+	}
 	it.next = it.data[:t+c]
 	it.data = it.data[t+c:]
-	it.err = err
+	it.err = nil
 	return true
 }
 

--- a/rlp/iterator_test.go
+++ b/rlp/iterator_test.go
@@ -57,3 +57,44 @@ func TestIterator(t *testing.T) {
 		t.Errorf("count wrong, expected %d got %d", i, exp)
 	}
 }
+
+func TestIteratorStopsOnMalformedElement(t *testing.T) {
+	// List with one valid single-byte item (0x01) and one malformed item header (0x81)
+	// missing its payload byte.
+	it, err := NewListIterator([]byte{0xC2, 0x01, 0x81})
+	if err != nil {
+		t.Fatalf("unexpected iterator creation error: %v", err)
+	}
+	if !it.Next() {
+		t.Fatal("expected first element to be readable")
+	}
+	if got := it.Value(); len(got) != 1 || got[0] != 0x01 {
+		t.Fatalf("unexpected first value: %x", got)
+	}
+	// Next must stop and surface the decode error.
+	if it.Next() {
+		t.Fatal("expected malformed element to stop iteration")
+	}
+	if it.Err() == nil {
+		t.Fatal("expected iteration error for malformed element")
+	}
+}
+
+func TestIteratorValueClearedAtEnd(t *testing.T) {
+	it, err := NewListIterator([]byte{0xC1, 0x01})
+	if err != nil {
+		t.Fatalf("unexpected iterator creation error: %v", err)
+	}
+	if !it.Next() {
+		t.Fatal("expected one element")
+	}
+	if got := it.Value(); len(got) != 1 || got[0] != 0x01 {
+		t.Fatalf("unexpected first value: %x", got)
+	}
+	if it.Next() {
+		t.Fatal("iterator should be exhausted")
+	}
+	if got := it.Value(); got != nil {
+		t.Fatalf("expected nil value after exhaustion, got %x", got)
+	}
+}


### PR DESCRIPTION
### Motivation
- Prevent malformed or signed inputs being accepted for unsigned/limited-width parsers and to tighten numeric validations.
- Avoid unexpected mutation of inputs and out-of-range panics in priority queues and math helpers.
- Harden framing logic to safely handle extremely large message sizes and make RLP iteration surface malformed data errors.
- Add unit tests that exercise edge-cases to prevent regressions.

### Description
- Tighten numeric parsing by rejecting sign-prefixed inputs in `ParseBig256` and `ParseUint64`, and disallow negative or non-positive fork block entries in `gatherForks` (also handle `nil` config).
- Make `Exp` non-destructive to its `base` by operating on a copy and add an index bounds check in `Byte` to handle negative indices.
- Improve `GetRandIntArray` to handle zero/negative bounds, cap `num` to `max`, and generate results via a seeded permutation for deterministic selection logic.
- Harden `LazyQueue` and `Prque` implementations by checking for nil/zero-value internals and out-of-range indices in `Remove`/`Update`/`Peek`/`Pop`/`PopItem`/`Size`/`Empty`/`Reset`, and guard `setIndex` callbacks when nil.
- Add a new `errMessageFrameTooLarge` and switch to 64-bit size checks in `p2p` frame writing to correctly detect and reject frame-size overflows without integer wraparound.
- Make RLP `listIterator.Next` surface decoding errors and clear `next`/`err` appropriately when exhausted or on error.
- Add a suite of unit tests across packages (`math`, `integer`, `prque`, `lazyqueue`, `forkid`, `p2p`, `rlp`) that cover the introduced edge cases and regressions.

### Testing
- Ran `go test ./...` including newly added tests such as `TestParseBig256RejectsNegative`, `TestExpDoesNotMutateBase`, `TestGetRandIntArrayBounds`, `TestLazyQueueRemoveOutOfRange`, `TestRemoveReturnsStoredValue` (prque), `TestGatherForksIgnoresNonPositiveBlocks`, `TestRLPXFrameRWRejectsFrameSizeOverflow`, and RLP iterator tests, and they all passed.
- Existing test suites for affected packages were executed and produced no failures after the changes.
- Targeted tests validate both successful behavior and correct failure modes for malformed inputs and out-of-range operations.
- The changes are unit-test driven and focused on preventing panics and incorrect acceptance of invalid data.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00fc1c18c8330a8370837dc74515e)