### PR TITLE
Prevent frame-size uint24 overflow in RLPx writer and add test

### DIFF
--- a/p2p/rlpx.go
+++ b/p2p/rlpx.go
@@ -601,10 +601,11 @@ func (rw *rlpxFrameRW) WriteMsg(msg Msg) error {
 	}
 	// write header
 	headbuf := make([]byte, 32)
-	fsize := uint32(len(ptype)) + msg.Size
-	if fsize > maxUint24 {
+	fsize64 := uint64(len(ptype)) + uint64(msg.Size)
+	if fsize64 > uint64(maxUint24) {
 		return errors.New("message size overflows uint24")
 	}
+	fsize := uint32(fsize64)
 	putInt24(fsize, headbuf) // TODO: check overflow
 	copy(headbuf[3:], zeroHeader)
 	rw.enc.XORKeyStream(headbuf[:16], headbuf[:16]) // first half is now encrypted

--- a/p2p/rlpx_test.go
+++ b/p2p/rlpx_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net"
 	"reflect"
 	"strings"
@@ -372,6 +373,23 @@ func TestRLPXFrameRW(t *testing.T) {
 		if !bytes.Equal(payload, wantPayload) {
 			t.Fatalf("msg payload mismatch:\ngot  %x\nwant %x", payload, wantPayload)
 		}
+	}
+}
+
+func TestRLPXFrameRWRejectsFrameSizeOverflow(t *testing.T) {
+	rw := newRLPXFrameRW(new(bytes.Buffer), secrets{
+		AES:        crypto.Keccak256(),
+		MAC:        crypto.Keccak256(),
+		IngressMAC: fakeHash(make([]byte, 32)),
+		EgressMAC:  fakeHash(make([]byte, 32)),
+	})
+	msg := Msg{
+		Code:    1,
+		Size:    math.MaxUint32,
+		Payload: bytes.NewReader(nil),
+	}
+	if err := rw.WriteMsg(msg); err == nil || err.Error() != "message size overflows uint24" {
+		t.Fatalf("expected overflow error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Avoid a uint24 overflow when computing the encrypted frame size from the plaintext type length plus the message size, which could produce an invalid header and break/compromise the protocol.  

### Description
- Compute the frame size as a `uint64`, check it against `maxUint24`, and only then cast to `uint32`, returning a clear error `message size overflows uint24` on overflow.  
- Add unit test `TestRLPXFrameRWRejectsFrameSizeOverflow` in `p2p/rlpx_test.go` that constructs a writer and verifies `WriteMsg` rejects an excessively large `Msg.Size`.  

### Testing
- Ran the new unit test with `go test ./p2p -run TestRLPXFrameRWRejectsFrameSizeOverflow` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00fc1c18c8330a8370837dc74515e)