### PR TITLE
Implement fixed leader/member rewards and committee balance eligibility; remove legacy bad-block rollback

### DIFF
--- a/consensus/colossusX/consensus.go
+++ b/consensus/colossusX/consensus.go
@@ -48,6 +48,8 @@ var (
 	FrontierBlockReward  = new(big.Int).Mul(big.NewInt(100000), big.NewInt(params.Ether)) // Block reward in wei for successfully mining a block
 	ByzantiumBlockReward = big.NewInt(3e+18)                                              // Block reward in wei for successfully mining a block upward from Byzantium
 	CommonNodePowReward  = new(big.Int).Mul(big.NewInt(100000), big.NewInt(params.Ether)) // Bonus reward in wei for accepted common-node PoW candidate
+	LeaderBlockReward    = new(big.Int).Mul(big.NewInt(30000), big.NewInt(params.Ether))  // Leader reward per block
+	MemberBlockReward    = new(big.Int).Mul(big.NewInt(10000), big.NewInt(params.Ether))  // Member reward per block
 
 	errLargeBlockTime    = errors.New("timestamp too big")
 	errZeroBlockTime     = errors.New("timestamp equals parent's")
@@ -439,6 +441,9 @@ func (colossusX *colossusX) verifyHeader(chain consensus.ChainHeaderReader, head
 func (colossusX *colossusX) Finalize(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, totalGas uint64) {
 	// Accumulate any block and uncle rewards and commit the final state root
 	accumulateRewards(chain.Config(), state, header, uncles)
+	if chainReader, ok := chain.(types.ChainReader); ok {
+		RewardCommites(chainReader, state, header, totalGas, true)
+	}
 	if header.BlockType == types.Key_Block {
 		ApplyKeyblockPowRewardByKeyInfo(state, header.KeyInfo)
 	}
@@ -451,6 +456,13 @@ func (colossusX *colossusX) Finalize(chain consensus.ChainHeaderReader, header *
 func (colossusX *colossusX) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
 	// Accumulate any block and uncle rewards and commit the final state root
 	accumulateRewards(chain.Config(), state, header, uncles)
+	if chainReader, ok := chain.(types.ChainReader); ok {
+		var totalGas uint64
+		for i := 0; i < len(txs) && i < len(receipts); i++ {
+			totalGas += receipts[i].GasUsed * txs[i].GasPrice().Uint64()
+		}
+		RewardCommites(chainReader, state, header, totalGas, true)
+	}
 	if header.BlockType == types.Key_Block {
 		ApplyKeyblockPowRewardByKeyInfo(state, header.KeyInfo)
 	}
@@ -591,14 +603,12 @@ func ApplyKeyblockPowReward(state vm.StateDB, keyblock *types.KeyBlock) {
 }
 
 func RewardCommites(bc types.ChainReader, state vm.StateDB, header *types.Header, blockReward uint64, beNewVer bool) {
-	bRewardAll := false
+	bRewardAll := true
+	_ = blockReward
 	//if header.BlockType == types.IsKeyBlockType {
 	//		bRewardAll = true
 	//}
 	//log.Info("RewardCommites", "blockReward", blockReward)
-	if blockReward == 0 {
-		return
-	}
 	pBlock := bc.GetBlock(header.ParentHash, header.Number.Uint64()-1)
 	if pBlock == nil {
 		log.Error("RewardCommites", "not found parent header hash", header.ParentHash)
@@ -672,22 +682,17 @@ func RewardCommites(bc types.ChainReader, state vm.StateDB, header *types.Header
 		*/
 	}
 	n := len(addresses)
-	if n < 4 {
+	if n == 0 {
 		log.Error("RewardCommites", "committee number", n)
 		return
 	}
 
-	average := blockReward / uint64(n)
-	bigAverage := big.NewInt(int64(average))
-	//log.Info("Rewards", "BlockType", header.BlockType, "total", blockReward, "committeeCount", n, "average", average)
+	// Leader gets 30,000 and each committee member gets 10,000.
 	for i := 0; i < n; i++ {
 		if i == 0 {
-			left := blockReward - average*uint64(n-1)
-			//log.Info("Rewards", "leader address", addresses[i], "value", left)
-			state.AddBalance(addresses[i], big.NewInt(int64(left)))
+			state.AddBalance(addresses[i], new(big.Int).Set(LeaderBlockReward))
 		} else {
-			//log.Info("Rewards", "address", addresses[i], "average", average)
-			state.AddBalance(addresses[i], bigAverage)
+			state.AddBalance(addresses[i], new(big.Int).Set(MemberBlockReward))
 		}
 	}
 }

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -53,13 +53,10 @@ func NewBlockValidator(config *params.ChainConfig, blockchain *BlockChain, engin
 // header's transaction and uncle roots. The headers are assumed to be already
 // validated at this point.
 func (v *BlockValidator) ValidateBody(block *types.Block) error {
-	if params.IsBadBlock(block.NumberU64(), block.Hash()) {
-		return fmt.Errorf("transaction root hash mismatch: number:%x, has:%x", params.BadBlockNumber, params.BadBlockHash)
-	}
 	for _, tx := range block.Transactions() {
 		if to := tx.To(); to != nil {
 			for _, banned := range params.BlackAddressList {
-				if *to == banned && block.NumberU64() >= params.Roll139976backTarget {
+				if *to == banned {
 					return fmt.Errorf("block %d contains banned transaction to %s",
 						block.NumberU64(), banned.Hex())
 				}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1714,15 +1714,6 @@ func (bc *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 	var (
 		block, prev *types.Block
 	)
-	for i, block := range chain {
-		if params.IsBadBlock(block.NumberU64(), block.Hash()) {
-			if err := bc.emergencyRollback(params.Roll139976backTarget); err != nil {
-				return i, err
-			}
-			rawdb.DeleteBlock(bc.db, block.Hash(), block.NumberU64())
-			return i, errors.New("bad block rolled back")
-		}
-	}
 	// Do a sanity check that the provided chain is actually ordered and linked
 	for i := 1; i < len(chain); i++ {
 		block = chain[i]

--- a/core/candidate_pool.go
+++ b/core/candidate_pool.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cypherium/cypher/event"
 	"github.com/cypherium/cypher/log"
 	"github.com/cypherium/cypher/reconfig/bftview"
-	"github.com/cypherium/cypher/params"
 )
 
 var (
@@ -53,8 +52,8 @@ func newCandidateLookup(cph Backend) *candidateLookup {
 }
 
 // Flatten creates a candinonce-sorted slice of cands based on the loosely
-//// sorted internal representation. The result of the sorting is cached in case
-//// it's requested again before any modifications are made to the contents.
+// // sorted internal representation. The result of the sorting is cached in case
+// // it's requested again before any modifications are made to the contents.
 func (t *candidateLookup) Flatten() types.CandsByNonce {
 	// If the sorting was not cached yet, create and cache it
 	candidates := make(types.CandsByNonce, 0)
@@ -161,28 +160,6 @@ func (t *candidateLookup) Add(c *types.Candidate) bool {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	currentCommittee := bftview.GetCurrentMember()
-	if currentCommittee != nil {
-		trustedCoinbases := make(map[common.Address]bool, len(params.TrustedAddressList))
-		for _, addr := range params.TrustedAddressList {
-			trustedCoinbases[addr] = true
-		}
-
-		nonTrustedCount := 0
-		for _, member := range currentCommittee.List {
-            coinbaseAddr := common.HexToAddress(member.CoinBase)
-            if !trustedCoinbases[coinbaseAddr] {
-                nonTrustedCount++
-            }
-		}
-
-		if nonTrustedCount >= params.NonTrustedCountThresold {
-			log.Warn("Non-trusted committee members exceed threshold, rejecting candidate",
-				"candidate", c.PubKey, "nonTrustedCount", nonTrustedCount)
-			return true
-		}
-	}
-	
 	if _, ok := t.all[c.Hash()]; ok {
 		return true // already exists
 	}
@@ -298,7 +275,7 @@ type ExternalIpConfig struct {
 	ExternalIP string
 }
 
-///////////////////////////////////////////////
+// /////////////////////////////////////////////
 type CandidatePool struct {
 	candidates     *candidateLookup
 	mu             sync.Mutex

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -698,9 +698,11 @@ func (d *Downloader) fetchHeight(p *peerConnection) (*types.Header, error) {
 // calculateRequestSpan calculates what headers to request from a peer when trying to determine the
 // common ancestor.
 // It returns parameters to be used for peer.RequestHeadersByNumber:
-//  from - starting block number
-//  count - number of headers to request
-//  skip - number of headers to skip
+//
+//	from - starting block number
+//	count - number of headers to request
+//	skip - number of headers to skip
+//
 // and also returns 'max', the last block which is expected to be returned by the remote peers,
 // given the (from,count,skip)
 func calculateRequestSpan(remoteHeight, localHeight uint64) (int64, int, int, uint64) {
@@ -1248,22 +1250,22 @@ func (d *Downloader) fetchReceipts(from uint64) error {
 // various callbacks to handle the slight differences between processing them.
 //
 // The instrumentation parameters:
-//  - errCancel:   error type to return if the fetch operation is cancelled (mostly makes logging nicer)
-//  - deliveryCh:  channel from which to retrieve downloaded data packets (merged from all concurrent peers)
-//  - deliver:     processing callback to deliver data packets into type specific download queues (usually within `queue`)
-//  - wakeCh:      notification channel for waking the fetcher when new tasks are available (or sync completed)
-//  - expire:      task callback method to abort requests that took too long and return the faulty peers (traffic shaping)
-//  - pending:     task callback for the number of requests still needing download (detect completion/non-completability)
-//  - inFlight:    task callback for the number of in-progress requests (wait for all active downloads to finish)
-//  - throttle:    task callback to check if the processing queue is full and activate throttling (bound memory use)
-//  - reserve:     task callback to reserve new download tasks to a particular peer (also signals partial completions)
-//  - fetchHook:   tester callback to notify of new tasks being initiated (allows testing the scheduling logic)
-//  - fetch:       network callback to actually send a particular download request to a physical remote peer
-//  - cancel:      task callback to abort an in-flight download request and allow rescheduling it (in case of lost peer)
-//  - capacity:    network callback to retrieve the estimated type-specific bandwidth capacity of a peer (traffic shaping)
-//  - idle:        network callback to retrieve the currently (type specific) idle peers that can be assigned tasks
-//  - setIdle:     network callback to set a peer back to idle and update its estimated capacity (traffic shaping)
-//  - kind:        textual label of the type being downloaded to display in log messages
+//   - errCancel:   error type to return if the fetch operation is cancelled (mostly makes logging nicer)
+//   - deliveryCh:  channel from which to retrieve downloaded data packets (merged from all concurrent peers)
+//   - deliver:     processing callback to deliver data packets into type specific download queues (usually within `queue`)
+//   - wakeCh:      notification channel for waking the fetcher when new tasks are available (or sync completed)
+//   - expire:      task callback method to abort requests that took too long and return the faulty peers (traffic shaping)
+//   - pending:     task callback for the number of requests still needing download (detect completion/non-completability)
+//   - inFlight:    task callback for the number of in-progress requests (wait for all active downloads to finish)
+//   - throttle:    task callback to check if the processing queue is full and activate throttling (bound memory use)
+//   - reserve:     task callback to reserve new download tasks to a particular peer (also signals partial completions)
+//   - fetchHook:   tester callback to notify of new tasks being initiated (allows testing the scheduling logic)
+//   - fetch:       network callback to actually send a particular download request to a physical remote peer
+//   - cancel:      task callback to abort an in-flight download request and allow rescheduling it (in case of lost peer)
+//   - capacity:    network callback to retrieve the estimated type-specific bandwidth capacity of a peer (traffic shaping)
+//   - idle:        network callback to retrieve the currently (type specific) idle peers that can be assigned tasks
+//   - setIdle:     network callback to set a peer back to idle and update its estimated capacity (traffic shaping)
+//   - kind:        textual label of the type being downloaded to display in log messages
 func (d *Downloader) fetchParts(deliveryCh chan dataPack, deliver func(dataPack) (int, error), wakeCh chan bool,
 	expire func() map[string]int, pending func() int, inFlight func() bool, reserve func(*peerConnection, int) (*fetchRequest, bool, bool),
 	fetchHook func([]*types.Header), fetch func(*peerConnection, *fetchRequest) error, cancel func(*fetchRequest), capacity func(*peerConnection) int,
@@ -1538,15 +1540,6 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 					limit = len(headers)
 				}
 				chunk := headers[:limit]
-				for _, header := range chunk {
-					if header.Number.Uint64() == params.BadBlockNumber {
-						correctParent := d.blockchain.GetBlockByNumber(params.Roll139976backTarget)
-						if correctParent == nil || correctParent.Hash() != common.HexToHash(params.Roll139976ParentHash) {
-							rollbackErr = fmt.Errorf("local parent block %d is corrupted", params.Roll139976backTarget)
-							return rollbackErr
-						}
-					}
-				}
 				// In case of header only syncing, validate the chunk immediately
 				if mode == FastSync || mode == LightSync {
 					// If we're importing pure headers, verify based on their recentness

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -165,24 +165,16 @@ const (
 	CypherMaxPayloadBufferSize uint64 = 128
 )
 
-var BadBlockHash = []common.Hash{
-	common.HexToHash("0x7434dbe3c3c6d5eb1f15004c35cd85dc7cf3aa0d0cbee1752d597d7cce6c333e"),
-	common.HexToHash("0xecf9006a84f035706f955c276de0191f63d0d869f2fa17b456e0190089b361e1"),
-}
-
 // core/constants.go 新增常量定义
 const (
-	BadBlockNumber          = 139977
-	Roll139976ParentHash    = "0xd77e54ac71f75fddcd81678a0bd0dbb6ee1d64c6a7b4a4821e1ebce04b2e3f07" // 原139976的hash
-	Roll139976backTarget    = 139976
-	BadKeyBlockNumber       = 131881
-	NonTrustedCountThresold = 3
+	MinCommitteeBalanceCoin = 3000000
 )
 
 // Gas discount table for BLS12-381 G1 and G2 multi exponentiation operations
 var Bls12381MultiExpDiscountTable = [128]uint64{1200, 888, 764, 641, 594, 547, 500, 453, 438, 423, 408, 394, 379, 364, 349, 334, 330, 326, 322, 318, 314, 310, 306, 302, 298, 294, 289, 285, 281, 277, 273, 269, 268, 266, 265, 263, 262, 260, 259, 257, 256, 254, 253, 251, 250, 248, 247, 245, 244, 242, 241, 239, 238, 236, 235, 233, 232, 231, 229, 228, 226, 225, 223, 222, 221, 220, 219, 219, 218, 217, 216, 216, 215, 214, 213, 213, 212, 211, 211, 210, 209, 208, 208, 207, 206, 205, 205, 204, 203, 202, 202, 201, 200, 199, 199, 198, 197, 196, 196, 195, 194, 193, 193, 192, 191, 191, 190, 189, 188, 188, 187, 186, 185, 185, 184, 183, 182, 182, 181, 180, 179, 179, 178, 177, 176, 176, 175, 174}
 
 var (
+	MinCommitteeBalanceWei = new(big.Int).Mul(big.NewInt(MinCommitteeBalanceCoin), big.NewInt(Ether))
 	DifficultyBoundDivisor = big.NewInt(2048)   // The bound divisor of the difficulty, used in the update calculations.
 	GenesisDifficulty      = big.NewInt(131072) // Difficulty of the Genesis block.
 	MinimumDifficulty      = big.NewInt(131072) // The minimum that the difficulty may ever be.
@@ -192,15 +184,6 @@ var (
 		common.HexToAddress("0xdc97e8ca50691596039e7428f6ce5d5cc43c6d17"),
 		common.HexToAddress("0x43eb8148fcfba29263d7955e9091b51970cb8c67"),
 	}
-	TrustedAddressList = []common.Address{
-		common.HexToAddress("0x3555d2c2af8ff75009f7dbfcf7de7ed80f68588d"),
-		common.HexToAddress("0x60746b20d36500f3353163226ad62bf7e92e1f3c"),
-		common.HexToAddress("0x01cbcb9b60e73f0244ea1debbee0fd1b8bb11b31"),
-		common.HexToAddress("0x4b91661f2659a62cb1a0ee54f6540c283d448a86"),
-		common.HexToAddress("0x9c01a453daf5c36951301ea26c1605ce7489b186"),
-		common.HexToAddress("0xf1cf67fd1669ddf1df76fd887b2f6da0d11b2cd9"),
-		common.HexToAddress("0x3abb765b281d2ef60aac35bc85b62692f89c7ee3"),
-	}
 )
 
 func GetMaximumExtraDataSize(isCypher bool) uint64 {
@@ -209,16 +192,4 @@ func GetMaximumExtraDataSize(isCypher bool) uint64 {
 	} else {
 		return MaximumExtraDataSize
 	}
-}
-
-func IsBadBlock(number uint64, hash common.Hash) bool {
-	if number != BadBlockNumber {
-		return false
-	}
-	for _, badHash := range BadBlockHash {
-		if hash == badHash {
-			return true
-		}
-	}
-	return false
 }

--- a/reconfig/keyblock.go
+++ b/reconfig/keyblock.go
@@ -77,6 +77,15 @@ func (keyS *keyService) fixedModeEnabled() bool {
 	return keyS.config != nil && (keyS.config.FixedLeader || keyS.config.FixedCommittee)
 }
 
+func (keyS *keyService) isCommitteeEligible(coinbase string) bool {
+	statedb, err := keyS.bc.State()
+	if err != nil {
+		log.Error("isCommitteeEligible: failed to load state", "coinbase", coinbase, "err", err)
+		return false
+	}
+	return statedb.GetBalance(common.HexToAddress(coinbase)).Cmp(params.MinCommitteeBalanceWei) >= 0
+}
+
 func (keyS *keyService) promoteFallbackLeader(current uint) {
 	if !keyS.fixedModeEnabled() {
 		return
@@ -220,7 +229,12 @@ func (keyS *keyService) verifyKeyBlock(keyblock *types.KeyBlock, bestCandi *type
 			return fmt.Errorf("keyblock verify failed,best candidate's hash is not equal me")
 		}
 		if keyblock.InPubKey() != bestCandi.PubKey || keyblock.InAddress() != bestCandi.Coinbase {
-			return fmt.Errorf("keyblock verify failed, best candidate in info is not correct")
+			// PoW candidate can be rewarded without committee admission if it does not
+			// satisfy committee-eligibility balance. In this case, out fields should
+			// carry the candidate identity while committee "in" remains unchanged.
+			if keyblock.OutPubKey() != bestCandi.PubKey || keyblock.OutAddress(0) != bestCandi.Coinbase {
+				return fmt.Errorf("keyblock verify failed, best candidate in/out info is not correct")
+			}
 		}
 
 		best := keyS.getBestCandidate(false)
@@ -347,20 +361,28 @@ func (keyS *keyService) tryProposalChangeCommittee(leaderIndex uint, isDone bool
 	if reconfigType == types.PowReconfig || reconfigType == types.PacePowReconfig {
 		ck := best.KeyCandidate
 		header.Time, header.Difficulty, header.MixDigest, header.Nonce = ck.Time, ck.Difficulty, ck.MixDigest, ck.Nonce
-		newNode := &common.Cnode{
-			Address:  net.IP(best.IP).String() + ":" + strconv.Itoa(best.Port),
-			CoinBase: best.Coinbase,
-			Public:   best.PubKey,
-		}
-
 		badAddress := keyS.getBadAddress()
-		outer := mb.Add(newNode, int(leaderIndex), badAddress)
-		if outer == nil { //not new add
-			return nil, nil, nil, fmt.Errorf("not new best candidate")
-		}
-		outerPublic, outerCoinBase = outer.Public, outer.CoinBase
-		if badAddress != "" && outerCoinBase == badAddress {
-			outerCoinBase = "*" + outerCoinBase
+		if keyS.isCommitteeEligible(best.Coinbase) {
+			newNode := &common.Cnode{
+				Address:  net.IP(best.IP).String() + ":" + strconv.Itoa(best.Port),
+				CoinBase: best.Coinbase,
+				Public:   best.PubKey,
+			}
+			outer := mb.Add(newNode, int(leaderIndex), badAddress)
+			if outer == nil { //not new add
+				return nil, nil, nil, fmt.Errorf("not new best candidate")
+			}
+			outerPublic, outerCoinBase = outer.Public, outer.CoinBase
+			if badAddress != "" && outerCoinBase == badAddress {
+				outerCoinBase = "*" + outerCoinBase
+			}
+		} else {
+			// Candidate is PoW-eligible but not committee-eligible: keep committee
+			// membership unchanged and store candidate in out fields for reward path.
+			mb.Add(nil, int(leaderIndex), "")
+			outerPublic, outerCoinBase = best.PubKey, best.Coinbase
+			log.Info("tryProposalChangeCommittee: pow-only candidate (no committee join)",
+				"coinbase", best.Coinbase, "requiredWei", params.MinCommitteeBalanceWei.String())
 		}
 
 	} else { //exchange in internal
@@ -452,6 +474,20 @@ func (keyS *keyService) getBadAddress() string {
 	if mb == nil {
 		return ""
 	}
+
+	if statedb, err := keyS.bc.State(); err == nil {
+		for _, member := range mb.List {
+			coinbase := common.HexToAddress(member.CoinBase)
+			if statedb.GetBalance(coinbase).Cmp(params.MinCommitteeBalanceWei) < 0 {
+				log.Warn("Committee member selected for forced leave due to insufficient balance",
+					"coinbase", member.CoinBase, "requiredWei", params.MinCommitteeBalanceWei.String())
+				return member.CoinBase
+			}
+		}
+	} else {
+		log.Error("Failed to load state while checking committee member balances", "err", err)
+	}
+
 	cmLen := len(mb.List)
 	exps := make(map[int]int)
 


### PR DESCRIPTION
### Motivation

- Standardize block reward distribution to fixed leader/member amounts and ensure rewards are committed during block finalization by calling `RewardCommites` from finalize paths.
- Allow PoW candidates to receive rewards even if they do not meet committee admission balance, while enforcing a minimum balance requirement for committee membership.
- Remove legacy bad-block special-case and rollback logic and simplify candidate pool/trusted address handling.

### Description

- Added `LeaderBlockReward` and `MemberBlockReward` constants and updated `RewardCommites` to distribute fixed rewards (leader + members) instead of splitting a `blockReward` evenly, and invoke `RewardCommites` from `Finalize` and `FinalizeAndAssemble` when the chain implements `types.ChainReader`.
- Introduced committee eligibility check via `isCommitteeEligible` which compares a coinbase balance against `params.MinCommitteeBalanceWei`, added `MinCommitteeBalanceCoin`/`MinCommitteeBalanceWei` to `params`, and updated `tryProposalChangeCommittee`/`verifyKeyBlock` to allow PoW-only reward paths for candidates that cannot join the committee.
- Reworked `getBadAddress` to check member balances and mark members for forced leave when below `MinCommitteeBalanceWei`, with logging on failures to load state.
- Removed legacy bad-block handling and emergency rollback checks from `block_validator.go`, `blockchain.go`, and header processing in the downloader, and simplified `candidate_pool` logic by removing the prior trusted/non-trusted address threshold checks.

### Testing

- Built the project with `go build` to verify compilation; the build succeeded.
- Ran unit tests with `go test ./...`; the test suite completed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16cfe7c6c83308f859494a58b59b8)