### PR TITLE
RescueCommittee: restrict rescue to trusted key heights and remove coinbase whitelist check

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -121,21 +121,6 @@ func (b *EthAPIBackend) RescueCommittee(configPath string) (*bftview.Committee, 
 		return nil, common.Hash{}, errors.New("keynumber not in trusted heights")
 	}
 
-	// Verify that all CoinBase addresses are in the trusted list
-	trustedSet := make(map[common.Address]bool)
-	for _, addr := range params.TrustedAddressList {
-		trustedSet[addr] = true
-	}
-
-	// Check each committee member's coinbase address
-	for _, cnode := range config.Committee {
-		// Convert CoinBase string to common.Address (case-insensitive)
-		coinbaseAddr := common.HexToAddress(cnode.CoinBase)
-		if !trustedSet[coinbaseAddr] {
-			return nil, common.Hash{}, fmt.Errorf("coinbase address %s is not in trusted list", cnode.CoinBase)
-		}
-	}
-	log.Info("equal all trustAdress!")
 	keyblock := b.eth.keyBlockChain.GetBlockByNumber(config.KeyBlockNumber)
 	if keyblock == nil {
 		return nil, common.Hash{}, errors.New("key block not found")


### PR DESCRIPTION
### Motivation

- Limit rescue operations to a predefined set of trusted key block heights and ensure the provided config refers to the newest key number.
- Remove the previous coinbase whitelist enforcement which validated each committee member against `params.TrustedAddressList`.

### Description

- Add a `rescueTrustHeights` slice (seeded with `178145`) and verify `currentKeyNumber == config.KeyBlockNumber` inside `RescueCommittee` with error `"not the newest keynumber"` when mismatched.
- Check membership of the current key number in `rescueTrustHeights` and return `"keynumber not in trusted heights"` if not trusted.
- Remove the trusted coinbase address map construction and the loop that validated each committee member's `CoinBase` against `params.TrustedAddressList`, plus the related log line.
- Preserve lookup of the key block via `b.eth.keyBlockChain.GetBlockByNumber` and return the `Committee` and key block hash as before.

### Testing

- Ran `go test ./eth -run TestRescueCommittee` which exercised `RescueCommittee` behavior and passed.
- Ran `go test ./...` to validate package-level changes and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18077ae808330be6474f573476546)