### PR TITLE
Compute total gas and call RewardCommites in tryProposalNewBlock

### DIFF
--- a/reconfig/txblock.go
+++ b/reconfig/txblock.go
@@ -131,6 +131,11 @@ func (txS *txService) tryProposalNewBlock(blockType uint8) ([]byte, error) {
 		header.KeyHash = txS.kbc.CurrentBlock().Hash()
 		// commit state root after all state transitions.
 		colossusX.AccumulateRewards(txS.bc.Config(), work.publicState, header, nil)
+		var totalGas uint64
+		for i := 0; i < len(committedTxes) && i < len(publicReceipts); i++ {
+			totalGas += publicReceipts[i].GasUsed * committedTxes[i].GasPrice().Uint64()
+		}
+		colossusX.RewardCommites(txS.bc, work.publicState, header, totalGas, true)
 		header.Root = work.publicState.IntermediateRoot(false)
 		header.BlockType = blockType
 


### PR DESCRIPTION
### Motivation
- Ensure reward distribution logic accounts for gas fees collected by the block proposer when creating a new block.
- Pass the aggregated gas-based fees into the reward commit step so rewards and state are updated consistently after transaction commits.

### Description
- Add computation of `totalGas` by summing `publicReceipts[i].GasUsed * committedTxes[i].GasPrice().Uint64()` for the committed transactions while guarding against length mismatches.
- Invoke `colossusX.RewardCommites(txS.bc, work.publicState, header, totalGas, true)` after `colossusX.AccumulateRewards` and before setting `header.Root` so gas-based rewards are applied to the public state.
- Preserve existing block header, log updates, and block construction behavior while extending the reward flow to include gas fees.

### Testing
- Ran `go test ./...` and the test suite completed successfully.
- Built the package to ensure compilation succeeds after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f192c83f4483308bd852c5e1ad5da3)