### PR TITLE
reconfig: trigger periodic keyblock generation in all modes

### DIFF
--- a/reconfig/paceMaker.go
+++ b/reconfig/paceMaker.go
@@ -158,13 +158,13 @@ func (t *paceMakerTimer) loopTimer() {
 		}
 
 		now := time.Now()
-		if t.config != nil && (t.config.FixedLeader || t.config.FixedCommittee) && bftview.IamMember() >= 0 {
+		if bftview.IamMember() >= 0 {
 			t.mu.Lock()
 			lastKeyTime := t.lastKeyTime
 			if now.Sub(lastKeyTime) >= fixedModeKeyBlockInterval {
 				t.lastKeyTime = now
 				t.mu.Unlock()
-				log.Warn("paceMakerTimer fixed mode keyblock trigger", "elapsed", now.Sub(lastKeyTime))
+				log.Warn("paceMakerTimer periodic keyblock trigger", "elapsed", now.Sub(lastKeyTime), "interval", fixedModeKeyBlockInterval)
 				t.setNextLeader(true)
 				continue
 			}


### PR DESCRIPTION
### Motivation
- Ensure committee members trigger key block proposals on the existing 10-minute cadence even when the node is not running in fixed leader/committee mode so periodic keyblock generation is consistent across modes.

### Description
- Removed the `t.config` fixed-mode guard in `reconfig/paceMaker.go` so the `loopTimer` now performs the 10-minute `fixedModeKeyBlockInterval` check whenever `bftview.IamMember() >= 0`, and updated the log message to `paceMakerTimer periodic keyblock trigger` to include the `interval` value.

### Testing
- Ran `go test ./reconfig/...` which could not execute in this environment due to module layout (`directory prefix reconfig does not contain main module or its selected dependencies`), and therefore no unit test failures were observed from the change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a08e234c8330b3af63803de4ab23)