### PR TITLE
Use chain IsEIP158 when computing proposed block state root

### DIFF
--- a/reconfig/txblock.go
+++ b/reconfig/txblock.go
@@ -84,7 +84,7 @@ func (txS *txService) tryProposalNewKeyBlock(keyblock *types.KeyBlock) ([]byte, 
 	// commit state root after all state transitions.
 	colossusX.AccumulateRewards(txS.bc.Config(), work.publicState, header, nil)
 	colossusX.ApplyKeyblockPowReward(work.publicState, keyblock)
-	header.Root = work.publicState.IntermediateRoot(false)
+	header.Root = work.publicState.IntermediateRoot(txS.bc.Config().IsEIP158(header.Number))
 
 	header.BlockType = types.Key_Block
 	header.Difficulty = keyblock.Difficulty()
@@ -136,7 +136,7 @@ func (txS *txService) tryProposalNewBlock(blockType uint8) ([]byte, error) {
 			totalGas += publicReceipts[i].GasUsed * committedTxes[i].GasPrice().Uint64()
 		}
 		colossusX.RewardCommites(txS.bc, work.publicState, header, totalGas, true)
-		header.Root = work.publicState.IntermediateRoot(false)
+		header.Root = work.publicState.IntermediateRoot(txS.bc.Config().IsEIP158(header.Number))
 		header.BlockType = blockType
 
 		// update block hash since it is now available, but was not when the


### PR DESCRIPTION
### Motivation
- Nodes were rejecting proposed tx blocks with `invalid merkle root` because the proposer computed the state root with a hardcoded `false` while validation uses the chain-config-driven EIP-158 flag.
- The change aims to align proposer-side state root generation with validator-side `ValidateState` behavior to eliminate root mismatches.

### Description
- Updated `reconfig/txblock.go` to compute `header.Root` using `work.publicState.IntermediateRoot(txS.bc.Config().IsEIP158(header.Number))` instead of `IntermediateRoot(false)` in the keyblock proposal path (`tryProposalNewKeyBlock`).
- Made the same change in the tx block proposal path (`tryProposalNewBlock`) so both proposal flows use the chain `IsEIP158(header.Number)` setting.
- This ensures proposer logic matches `core/block_validator.go`'s `ValidateState` which uses `statedb.IntermediateRoot(v.config.IsEIP158(header.Number))`.

### Testing
- Ran `go test ./reconfig/...` which failed due to module setup error (`pattern ./reconfig/...: directory prefix reconfig does not contain main module or its selected dependencies`).
- Ran `go test ./...` which failed for the same reason (`pattern ./...: directory prefix . does not contain main module or its selected dependencies`).
- Changes were committed to `reconfig/txblock.go` and no repository-level automated tests could be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a58789f88330bfb75ac0a3475397)