### PR TITLE
reconfig: ensure 10-minute keyblock trigger runs even when tx pacing is idle

### DIFF
--- a/reconfig/paceMaker.go
+++ b/reconfig/paceMaker.go
@@ -153,10 +153,6 @@ func (t *paceMakerTimer) loopTimer() {
 			return
 		}
 
-		if beStop || startTime == maxPaceMakerTime {
-			continue
-		}
-
 		now := time.Now()
 		if bftview.IamMember() >= 0 {
 			t.mu.Lock()
@@ -169,6 +165,10 @@ func (t *paceMakerTimer) loopTimer() {
 				continue
 			}
 			t.mu.Unlock()
+		}
+
+		if beStop || startTime == maxPaceMakerTime {
+			continue
 		}
 
 		diff := now.Sub(startTime)


### PR DESCRIPTION
### Motivation
- The periodic 10-minute keyblock trigger was placed behind the pacemaker's `beStop`/`startTime` guard, so when tx-block pacing was idle the periodic check never executed and key blocks could fail to be generated.

### Description
- Move the `fixedModeKeyBlockInterval` check in `paceMakerTimer.loopTimer` to run before the `if beStop || startTime == maxPaceMakerTime` gate so that committee nodes invoke `t.setNextLeader(true)` every `fixedModeKeyBlockInterval` regardless of tx-block pacing state.

### Testing
- Attempted to run `go test ./reconfig/...`, but the run failed due to Go module layout in this environment with the error `directory prefix reconfig does not contain main module or its selected dependencies`, so no automated package tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b1f6b604833086c0814ada15c449)