### PR TITLE
Suppress proposals when tx pool is empty and refine pacemaker timing behavior

### DIFF
--- a/reconfig/paceMaker.go
+++ b/reconfig/paceMaker.go
@@ -153,10 +153,6 @@ func (t *paceMakerTimer) loopTimer() {
 			return
 		}
 
-		if beStop || startTime == maxPaceMakerTime {
-			continue
-		}
-
 		now := time.Now()
 		if bftview.IamMember() >= 0 {
 			t.mu.Lock()
@@ -171,9 +167,20 @@ func (t *paceMakerTimer) loopTimer() {
 			t.mu.Unlock()
 		}
 
+		if beStop || startTime == maxPaceMakerTime {
+			continue
+		}
+
 		diff := now.Sub(startTime)
 		leaderSilentFor := now.Sub(t.service.LeaderAckTime())
 		progressSilentFor := now.Sub(t.service.HotstuffProgressTime())
+		pending, _ := t.txPool.Stats()
+		noPendingTx := pending == 0
+		sinceLastKey := now.Sub(t.lastKeyTime)
+		if noPendingTx && sinceLastKey < fixedModeKeyBlockInterval {
+			t.resetAckMissCount()
+			continue
+		}
 		fixedMode := t.config != nil && (t.config.FixedLeader || t.config.FixedCommittee)
 		if leaderSilentFor > params.AckTimeout && bftview.IamMember() >= 0 {
 			if progressSilentFor <= params.AckTimeout {

--- a/reconfig/service.go
+++ b/reconfig/service.go
@@ -555,7 +555,8 @@ func (s *Service) handleHotStuffMsg() {
 			time.Sleep(hotstuffIdleSleep)
 			now := time.Now()
 			if bftview.IamLeader(s.GetCurrentView().LeaderIndex) {
-				if s.shouldEmitFastBlock(now) || s.shouldEmitSlowBlock(now) {
+				pending, _ := s.txPool.Stats()
+				if pending > 0 && (s.shouldEmitFastBlock(now) || s.shouldEmitSlowBlock(now)) {
 					if s.lastCadenceWakeup.IsZero() || now.Sub(s.lastCadenceWakeup) >= 50*time.Millisecond {
 						s.lastCadenceWakeup = now
 						s.triggerTryPropose(s.bc.CurrentBlockN())


### PR DESCRIPTION
### Motivation

- Prevent the node from triggering proposals or view changes when there are no pending transactions to include, reducing unnecessary leader activity and view churn.
- Ensure pacemaker keyblock/ack-miss logic respects recent key generation and pending transaction state to avoid spurious fallback in fixed-leader/fixed-committee modes.

### Description

- Updated `paceMakerTimer.loopTimer` to query the transaction pool via `t.txPool.Stats()` and skip pacemaker fallback logic when there are no pending transactions and the last keyblock is recent, calling `t.resetAckMissCount()` and `continue` in that case.
- Reordered the stop/close check in `paceMakerTimer.loopTimer` to occur after the periodic keyblock trigger check so keyblock timing is still enforced before skipping work for stopped timers.
- Added a `noPendingTx` guard to `Service.handleHotStuffMsg` so the leader only attempts cadence wakeups and proposal triggers when `pending > 0`, using `s.txPool.Stats()` to inspect the pool.
- Preserved existing fixed-mode ack-miss counting and fallback behavior while resetting the miss count when appropriate to avoid premature view changes.

### Testing

- Ran the repository test suite with `go test ./...` and the tests completed successfully.
- Built the service binary and ran basic startup smoke checks which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1b1f6b604833086c0814ada15c449)