### PR TITLE
Fix tx pool sender lookup compile error

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"errors"
-	"fmt"
 	"math"
 	"math/big"
 	"sort"
@@ -813,6 +812,8 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 		invalidTxMeter.Mark(1)
 		return false, err
 	}
+	from, _ := types.Sender(pool.signer, tx) // already validated
+
 	// If the transaction pool is full, discard underpriced transactions
 	if uint64(pool.all.Slots()+numSlots(tx)) > pool.config.GlobalSlots+pool.config.GlobalQueue {
 		// If the new transaction is underpriced, don't accept it


### PR DESCRIPTION
### Motivation
- Resolve compile-time errors in `core/tx_pool.go` caused by an unused import and an undefined `from` variable that break `make cypher`.
- Ensure `TxPool.add` has the sender (`from`) available for pending replacement, queueing, local-account marking, journaling, and logging.

### Description
- Removed the unused `fmt` import from `core/tx_pool.go`.
- Restored the sender derivation with `from, _ := types.Sender(pool.signer, tx)` immediately after `validateTx` in `TxPool.add` so `from` is defined for subsequent code paths.
- Applied `gofmt` to `core/tx_pool.go` to keep formatting consistent.

### Testing
- Ran `git diff --check` which produced no whitespace/format issues and succeeded.
- Ran `make cypher` which failed in this environment because the repository is not initialized as a Go module, producing `no required module provides package ...` errors.
- Ran `GO111MODULE=off go test ./core` which failed because the repository was not available under a GOPATH layout and internal imports could not be resolved.
- Created a GOPATH symlink and ran `GO111MODULE=off make cypher` which progressed past the fixed `fmt`/`from` compile errors but then failed due to missing vendored/GOPATH dependencies (for example `golang.org/x/sys/unix`, `github.com/VictoriaMetrics/fastcache`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea9effd2c83308eb0409b6ac9d7c2)