### PR TITLE
Fix Windows BLS cgo link flags

### DIFF
--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -2,15 +2,20 @@ package bls
 
 /*
 #cgo CFLAGS:-DMCLBN_FP_UNIT_SIZE=4 -Iinclude
-#cgo LDFLAGS: -Llib -lbls256 -lmcl
+#cgo !windows LDFLAGS: -Llib -lbls256 -lmcl
+#cgo windows LDFLAGS: -Llib/win -lbls256 -lmcl
 
 #cgo bn256 CFLAGS:-DMCLBN_FP_UNIT_SIZE=4 -Iinclude
-#cgo bn256 LDFLAGS: -Llib -lbls256 -lmcl
+#cgo bn256,!windows LDFLAGS: -Llib -lbls256 -lmcl
+#cgo bn256,windows LDFLAGS: -Llib/win -lbls256 -lmcl
 #cgo bn384 CFLAGS:-DMCLBN_FP_UNIT_SIZE=6 -Iinclude
-#cgo bn384 LDFLAGS: -Llib -lbls384 -lmcl
+#cgo bn384,!windows LDFLAGS: -Llib -lbls384 -lmcl
+#cgo bn384,windows LDFLAGS: -Llib/win -lbls384 -lmcl
 #cgo bn384_256 CFLAGS:-DMCLBN_FP_UNIT_SIZE=6 -DMCLBN_FR_UNIT_SIZE=4 -Iinclude
-#cgo bn384_256 LDFLAGS: -Llib -lbls384_256 -lmcl
-#cgo LDFLAGS:-L/usr/local/opt/openssl/lib -lcrypto -lgmp -lgmpxx -lstdc++
+#cgo bn384_256,!windows LDFLAGS: -Llib -lbls384_256 -lmcl
+#cgo bn384_256,windows LDFLAGS: -Llib/win -lbls384_256 -lmcl
+#cgo !windows LDFLAGS:-L/usr/local/opt/openssl/lib -lcrypto -lgmp -lgmpxx -lstdc++
+#cgo windows LDFLAGS:-lcrypto -Wl,-Bstatic -lgmpxx -lgmp -lstdc++ -Wl,-Bdynamic
 
 #cgo bn256_swapg CFLAGS:-DMCLBN_FP_UNIT_SIZE=4 -DBLS_SWAP_G
 #cgo bn256_swapg LDFLAGS:-lbls256
@@ -18,7 +23,8 @@ package bls
 #cgo bn384_swapg LDFLAGS:-lbls384
 #cgo bn384_256_swapg CFLAGS:-DMCLBN_FP_UNIT_SIZE=6 -DMCLBN_FR_UNIT_SIZE=4 -DBLS_SWAP_G
 #cgo bn384_256_swapg LDFLAGS:-lbls384_256
-#cgo LDFLAGS:-lcrypto -lgmp -lgmpxx -lstdc++
+#cgo !windows LDFLAGS:-lcrypto -lgmp -lgmpxx -lstdc++
+#cgo windows LDFLAGS:-lcrypto -Wl,-Bstatic -lgmpxx -lgmp -lstdc++ -Wl,-Bdynamic
 typedef unsigned int (*ReadRandFunc)(void *, void *, unsigned int);
 int wrapReadRandCgo(void *self, void *buf, unsigned int n);
 #include <bls/bls.h>


### PR DESCRIPTION
### Motivation
- The Windows build copies Herumi BLS/mcl static libraries into `crypto\bls\lib\win` while cgo was still linking against `crypto/bls/lib`, causing mismatched linking on Windows and runtime pseudo-relocation failures from MinGW-w64.
- Statically linking GMP/GMPXX/libstdc++ on Windows prevents MinGW runtime relocation errors that occur when DLLs and the EXE are loaded out of 32-bit relative range.

### Description
- Update cgo directives in `crypto/bls/bls.go` to use platform-conditional flags so non-Windows builds keep the original `-Llib` behaviour and Windows builds use `-Llib/win` for BLS/mcl libraries. 
- Add Windows-specific `#cgo windows LDFLAGS` that request static linking of `gmpxx`, `gmp` and `libstdc++` (via `-Wl,-Bstatic`/`-Wl,-Bdynamic`) to avoid MinGW pseudo-relocation issues.
- Preserve existing non-Windows `LDFLAGS` (Linux/macOS) so Unix builds are unchanged.
- Aligns cgo linking with `build_windows.ps1` which produces/copies the Windows static libs into `crypto\bls\lib\win`.

### Testing
- Ran `GO111MODULE=off go test ./crypto/bls`, which completed successfully (ok).
- Ran repository diff/whitespace checks (`git -c core.whitespace=... diff --check`) and they reported no actionable issues after fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003de5a2588330a6bfcac303b6e86d)