### PR TITLE
Make miner thread count configurable via CLI and RPC and propagate to consensus engine

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1434,6 +1434,13 @@ func SetExternalIp(ctx *cli.Context, cfg *node.Config, cphcg *eth.Config) {
 }
 
 func setMiner(ctx *cli.Context, cfg *miner.Config) {
+	if ctx.GlobalIsSet(LegacyMinerThreadsFlag.Name) {
+		cfg.Threads = ctx.GlobalInt(LegacyMinerThreadsFlag.Name)
+		log.Warn("The flag --minerthreads is deprecated and will be removed in the future, please use --miner.threads")
+	}
+	if ctx.GlobalIsSet(MinerThreadsFlag.Name) {
+		cfg.Threads = ctx.GlobalInt(MinerThreadsFlag.Name)
+	}
 	if ctx.GlobalIsSet(MinerNotifyFlag.Name) {
 		cfg.Notify = strings.Split(ctx.GlobalString(MinerNotifyFlag.Name), ",")
 	}

--- a/eth/api.go
+++ b/eth/api.go
@@ -158,7 +158,12 @@ func (api *PrivateMinerAPI) Start(threads *int, addr common.Address, password st
 	)
 
 	if api.e.IsMining() {
-		return fmt.Errorf("Miner is running...")
+		miningThreads := api.e.config.Miner.Threads
+		if threads != nil {
+			miningThreads = *threads
+		}
+		api.e.setMiningThreads(miningThreads)
+		return nil
 	}
 	//log.Info("miner.start", "threads", threads, "addr", addr, "passwd", password)
 
@@ -194,21 +199,13 @@ func (api *PrivateMinerAPI) Start(threads *int, addr common.Address, password st
 	server.Port = api.e.config.RnetPort
 	server.Coinbase = eb.Hex()
 	api.e.reconfig.MinerStart(server)
-	// Start the miner and return
-	// Set the number of threads if the seal engine supports it
-	//if threads == nil {
-	//	threads = new(int)
-	//} else if *threads == 0 {
-	//	*threads = -1 // Disable the miner from within
-	//}
-	//type threaded interface {
-	//	SetThreads(threads int)
-	//}
-	//if th, ok := api.e.engine.(threaded); ok {
-	//	log.Info("Updated mining threads", "threads", *threads)
-	//	th.SetThreads(*threads)
-	//}
-	return api.e.StartMining(true, eb, blsPublicKey)
+	// Start the miner and return. If the RPC call does not provide a thread
+	// count, use the CLI/TOML miner configuration.
+	miningThreads := api.e.config.Miner.Threads
+	if threads != nil {
+		miningThreads = *threads
+	}
+	return api.e.StartMining(true, eb, blsPublicKey, miningThreads)
 }
 
 // Stop terminates the miner, both at the consensus engine level as well as at

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -285,12 +285,14 @@ func makeExtraData(extra []byte, hasPrivate bool) []byte {
 func CreateConsensusEngine(stack *node.Node, chainConfig *params.ChainConfig, config *Config) consensus.Engine {
 	s := config.colossusX
 	engine := colossusX.New(colossusX.Config{
-		CacheDir:       stack.ResolvePath(s.CacheDir),
-		CachesInMem:    s.CachesInMem,
-		CachesOnDisk:   s.CachesOnDisk,
-		DatasetDir:     s.DatasetDir,
-		DatasetsInMem:  s.DatasetsInMem,
-		DatasetsOnDisk: s.DatasetsOnDisk,
+		CacheDir:         stack.ResolvePath(s.CacheDir),
+		CachesInMem:      s.CachesInMem,
+		CachesOnDisk:     s.CachesOnDisk,
+		CachesLockMmap:   s.CachesLockMmap,
+		DatasetDir:       s.DatasetDir,
+		DatasetsInMem:    s.DatasetsInMem,
+		DatasetsOnDisk:   s.DatasetsOnDisk,
+		DatasetsLockMmap: s.DatasetsLockMmap,
 	})
 	//	engine := colossusX.NewNormal()
 	engine.SetThreads(-1) // Disable CPU mining
@@ -514,7 +516,19 @@ func (s *Ethereum) StopMining() {
 }
 */
 func (s *Ethereum) ServiceIsRunning() bool { return s.reconfig.ServiceIsRunning() }
-func (s *Ethereum) StartMining(local bool, eb common.Address, pubKey []byte) error {
+
+func (s *Ethereum) setMiningThreads(threads int) {
+	type threaded interface {
+		SetThreads(threads int)
+	}
+	if th, ok := s.engine.(threaded); ok {
+		log.Info("Updated mining threads", "threads", threads)
+		th.SetThreads(threads)
+	}
+}
+
+func (s *Ethereum) StartMining(local bool, eb common.Address, pubKey []byte, threads int) error {
+	s.setMiningThreads(threads)
 	// If the miner was not running, initialize it
 	if !s.IsMining() {
 		s.lock.RLock()
@@ -528,6 +542,7 @@ func (s *Ethereum) StartMining(local bool, eb common.Address, pubKey []byte) err
 }
 
 func (s *Ethereum) StopMining() {
+	s.setMiningThreads(-1)
 	s.miner.Stop()
 }
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -34,6 +34,7 @@ type Config struct {
 	Etherbase              common.Address `toml:",omitempty"` // Public address for block mining rewards (default = first account)
 	Notify                 []string       `toml:",omitempty"` // HTTP URL list to be notified of new work packages(only useful in colossusX).
 	ExtraData              hexutil.Bytes  `toml:",omitempty"` // Block extra data set by the miner
+	Threads                int            `toml:",omitempty"` // Number of CPU threads to use for mining (0 = all cores).
 	GasFloor               uint64         // Target gas floor for mined blocks.
 	GasCeil                uint64         // Target gas ceiling for mined blocks.
 	GasPrice               *big.Int       // Minimum gas price for mining a transaction


### PR DESCRIPTION
### Motivation
- Allow configuring the number of CPU threads used for mining from both the CLI/TOML and the RPC, and preserve backward compatibility with the legacy `--minerthreads` flag. 
- Ensure the consensus engine thread count is updated consistently when mining is started, adjusted, or stopped. 
- Surface colossusX memory-mapping lock options from config into the engine initialization. 

### Description
- Add a `Threads` field to `miner.Config` to represent the configured miner thread count. 
- Read both legacy `--minerthreads` and new `--miner.threads` flags in `setMiner`, applying the value and emitting a deprecation `log.Warn` when the legacy flag is used. 
- Introduce `setMiningThreads` on `Ethereum` and update `StartMining` to accept a `threads` argument and always apply the thread count to the consensus engine before starting mining. 
- Update `PrivateMinerAPI.Start` to adjust threads when the miner is already running and to pass the selected thread count into `StartMining` when initiating mining. 
- Ensure stopping mining resets the engine threads to `-1` in both `Ethereum.StopMining` and `PrivateMinerAPI.Stop`. 
- Enable `CachesLockMmap` and `DatasetsLockMmap` to be passed into the `colossusX` engine configuration during creation. 

### Testing
- Built the project with `go build` to validate compilation after the API and signature changes and the build succeeded. 
- Ran unit tests with `go test ./...` and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00a9a4336483309aa1a68eeb4d68f9)