### PR TITLE
Enforce minimum keyblock interval and suppress premature keyblock proposals

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -293,9 +293,9 @@ func (self *worker) commitNewWork() {
 		}
 	}
 	tstamp := tstart.Unix()
-	kstamp := int64(keyBlock.Time())
-	if kstamp >= tstamp {
-		tstamp = kstamp + 1
+	minKeyBlockTime := int64(keyBlock.Time()) + int64(params.KeyBlockMinInterval/time.Second)
+	if minKeyBlockTime > tstamp {
+		tstamp = minKeyBlockTime
 	}
 	// this will ensure we're not going off too far in the future
 	if now := time.Now().Unix(); tstamp > now+1 {
@@ -306,6 +306,7 @@ func (self *worker) commitNewWork() {
 
 	port, _ := strconv.Atoi(self.config.RnetPort)
 	candidate := types.NewCandidate(keyBlock.Hash(), nil, keyBlock.Number().Uint64()+uint64(1), txBlock.NumberU64(), nil, self.IP, common.HexString(self.pubKey), self.coinBase.String(), port)
+	candidate.KeyCandidate.Time = uint64(tstamp)
 	committeeSize := len(self.eth.KeyBlockChain().CurrentCommittee())
 
 	if err := self.engine.PrepareCandidate(self.chain, candidate, committeeSize); err != nil {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -29,6 +29,7 @@ const (
 	HeatBeatTimeout        = 10 * time.Second
 	PaceMakerTimeout       = 3 * time.Minute
 	KeyBlockTimeout        = 20 * time.Minute
+	KeyBlockMinInterval    = 10 * time.Minute
 	KeyBlock_Reward        = 1e+18 // Block reward in wei for successfully mining a block
 	CheckBackNumber        = 10
 	CollectVoteInfoTimeout = 5 * time.Second

--- a/reconfig/keyblock.go
+++ b/reconfig/keyblock.go
@@ -139,6 +139,14 @@ func (keyS *keyService) syncPrimaryLeaderLocked(mb *bftview.Committee) {
 	}
 }
 
+func verifyKeyBlockMinInterval(keyblock, curKeyblock *types.KeyBlock) error {
+	minNextKeyTime := curKeyblock.Time() + uint64(params.KeyBlockMinInterval/time.Second)
+	if keyblock.Time() < minNextKeyTime {
+		return fmt.Errorf("verifyKeyBlock,timestamp too early, min:%d, got:%d", minNextKeyTime, keyblock.Time())
+	}
+	return nil
+}
+
 // Verify keyblock
 func (keyS *keyService) verifyKeyBlock(keyblock *types.KeyBlock, bestCandi *types.Candidate) error { //
 	log.Info("@verifyKeyBlock", "number", keyblock.NumberU64())
@@ -151,6 +159,9 @@ func (keyS *keyService) verifyKeyBlock(keyblock *types.KeyBlock, bestCandi *type
 		if keyblock.ParentHash() != curKeyblock.Hash() {
 			//log.Error("verifyKeyBlock", "Non contiguous consensus prevhash", keyblock.ParentHash(), "currenthash", curKeyblock.Hash())
 			return fmt.Errorf("verifyKeyBlock,Non contiguous key block's hash")
+		}
+		if err := verifyKeyBlockMinInterval(keyblock, curKeyblock); err != nil {
+			return err
 		}
 		return nil
 	}
@@ -187,6 +198,9 @@ func (keyS *keyService) verifyKeyBlock(keyblock *types.KeyBlock, bestCandi *type
 	if keyblock.ParentHash() != curKeyblock.Hash() {
 		//log.Error("verifyKeyBlock", "Non contiguous consensus prevhash", keyblock.ParentHash(), "currenthash", curKeyblock.Hash())
 		return fmt.Errorf("verifyKeyBlock,Non contiguous key block's hash")
+	}
+	if err := verifyKeyBlockMinInterval(keyblock, curKeyblock); err != nil {
+		return err
 	}
 	if keyblock.T_Number() != keyS.bc.CurrentBlockN() {
 		return fmt.Errorf("verifyKeyBlock, T_Number is not current, cur tx number:%d, k_t_number:%d", keyS.bc.CurrentBlockN(), keyblock.T_Number())

--- a/reconfig/paceMaker.go
+++ b/reconfig/paceMaker.go
@@ -29,7 +29,6 @@ import (
 )
 
 var maxPaceMakerTime time.Time
-var fixedModeKeyBlockInterval = 10 * time.Minute
 var paceMakerPollInterval = 10 * time.Millisecond
 
 type paceMakerTimer struct {
@@ -161,7 +160,7 @@ func (t *paceMakerTimer) loopTimer() {
 		if t.config != nil && (t.config.FixedLeader || t.config.FixedCommittee) && bftview.IamMember() >= 0 {
 			t.mu.Lock()
 			lastKeyTime := t.lastKeyTime
-			if now.Sub(lastKeyTime) >= fixedModeKeyBlockInterval {
+			if now.Sub(lastKeyTime) >= params.KeyBlockMinInterval {
 				t.lastKeyTime = now
 				t.mu.Unlock()
 				log.Warn("paceMakerTimer fixed mode keyblock trigger", "elapsed", now.Sub(lastKeyTime))

--- a/reconfig/service.go
+++ b/reconfig/service.go
@@ -360,7 +360,18 @@ func (s *Service) Propose() (e error, kState []byte, tState []byte, extra []byte
 		// keyblock trigger has marked the current view as not done.
 		keyProposal = !noDone
 	}
-	if keyProposal {
+	keyBlockIntervalElapsed := true
+	if curKeyblock := s.kbc.CurrentBlock(); curKeyblock != nil {
+		lastKeyTime := time.Unix(int64(curKeyblock.Time()), 0)
+		keyBlockIntervalElapsed = time.Since(lastKeyTime) >= params.KeyBlockMinInterval
+		if keyProposal && !keyBlockIntervalElapsed {
+			log.Debug("Propose keyblock suppressed by minimum interval",
+				"elapsed", time.Since(lastKeyTime),
+				"minimum", params.KeyBlockMinInterval,
+				"lastKeyTime", lastKeyTime)
+		}
+	}
+	if keyProposal && keyBlockIntervalElapsed {
 		keyblock, mb, bestCandi, err := s.keyService.tryProposalChangeCommittee(leaderIndex, !noDone)
 		if err == nil && keyblock != nil && mb != nil {
 			if bestCandi != nil {


### PR DESCRIPTION
### Motivation

- Prevent key blocks from being created or accepted with timestamps that are too close together by enforcing a minimum interval between key blocks. 
- Ensure miner-generated candidate timestamps respect the minimum interval so miners do not mine into the near future. 
- Align pace-maker and propose logic with the same minimum interval to avoid rapid keyblock churn in fixed-leader/fixed-committee modes.

### Description

- Introduced a new protocol parameter `KeyBlockMinInterval` in `params` to centralize the minimum delay between consecutive key blocks. 
- Updated the miner `commitNewWork` logic to compute candidate timestamps using the configured minimum interval and assign it to `candidate.KeyCandidate.Time`. 
- Added `verifyKeyBlockMinInterval` and integrated it into `verifyKeyBlock` to reject key blocks with timestamps earlier than the allowed minimum. 
- Replaced the hardcoded `fixedModeKeyBlockInterval` with `params.KeyBlockMinInterval` in the pace-maker loop to throttle fixed-mode keyblock triggers. 
- Added suppression logic in `Service.Propose` to avoid proposing a key block if the last key block is younger than `KeyBlockMinInterval`, with a debug log when suppression occurs.

### Testing

- Ran unit tests with `go test ./...` across the repo and all tests completed successfully. 
- Built the node and exercised keyblock proposal paths in a local test environment to validate the suppression and timestamp handling (no failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092d78c1b88330a66c997cc12359e0)