### PR TITLE
Enforce minimum keyblock interval

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -291,9 +291,9 @@ func (self *worker) commitNewWork() {
 		}
 	}
 	tstamp := tstart.Unix()
-	kstamp := int64(keyBlock.Time())
-	if kstamp >= tstamp {
-		tstamp = kstamp + 1
+	minKeyBlockTime := int64(keyBlock.Time()) + int64(params.KeyBlockMinInterval/time.Second)
+	if minKeyBlockTime > tstamp {
+		tstamp = minKeyBlockTime
 	}
 	// this will ensure we're not going off too far in the future
 	if now := time.Now().Unix(); tstamp > now+1 {
@@ -304,6 +304,7 @@ func (self *worker) commitNewWork() {
 
 	port, _ := strconv.Atoi(self.config.RnetPort)
 	candidate := types.NewCandidate(keyBlock.Hash(), nil, keyBlock.Number().Uint64()+uint64(1), txBlock.NumberU64(), nil, self.IP, common.HexString(self.pubKey), self.coinBase.String(), port)
+	candidate.KeyCandidate.Time = uint64(tstamp)
 	committeeSize := len(self.eth.KeyBlockChain().CurrentCommittee())
 
 	if err := self.engine.PrepareCandidate(self.chain, candidate, committeeSize); err != nil {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -31,6 +31,7 @@ const (
 	HeatBeatTimeout        = 10 * time.Second
 	PaceMakerTimeout       = 3 * time.Minute
 	KeyBlockTimeout        = 20 * time.Minute
+	KeyBlockMinInterval    = 10 * time.Minute
 	KeyBlock_Reward        = 1e+18 // Block reward in wei for successfully mining a block
 	CheckBackNumber        = 10
 	CollectVoteInfoTimeout = 5 * time.Second

--- a/reconfig/keyblock.go
+++ b/reconfig/keyblock.go
@@ -61,6 +61,13 @@ func newKeyService(s serviceI, backend *ReconfigBackend, config *params.ChainCon
 func (keyS *keyService) verifyKeyBlock(keyblock *types.KeyBlock, bestCandi *types.Candidate) error { //
 	log.Info("@verifyKeyBlock", "number", keyblock.NumberU64())
 	kbc := keyS.kbc
+	checkKeyBlockMinInterval := func(curKeyblock *types.KeyBlock) error {
+		minNextKeyTime := curKeyblock.Time() + uint64(params.KeyBlockMinInterval/time.Second)
+		if keyblock.Time() < minNextKeyTime {
+			return fmt.Errorf("verifyKeyBlock,timestamp too early, min:%d, got:%d", minNextKeyTime, keyblock.Time())
+		}
+		return nil
+	}
 	if keyblock.LeaderPubKey() == bftview.GetServerInfo(bftview.PublicKey) {
 		curKeyblock := kbc.CurrentBlock()
 		if keyblock.NumberU64() != curKeyblock.NumberU64()+1 {
@@ -69,6 +76,9 @@ func (keyS *keyService) verifyKeyBlock(keyblock *types.KeyBlock, bestCandi *type
 		if keyblock.ParentHash() != curKeyblock.Hash() {
 			//log.Error("verifyKeyBlock", "Non contiguous consensus prevhash", keyblock.ParentHash(), "currenthash", curKeyblock.Hash())
 			return fmt.Errorf("verifyKeyBlock,Non contiguous key block's hash")
+		}
+		if err := checkKeyBlockMinInterval(curKeyblock); err != nil {
+			return err
 		}
 		return nil
 	}
@@ -105,6 +115,9 @@ func (keyS *keyService) verifyKeyBlock(keyblock *types.KeyBlock, bestCandi *type
 	if keyblock.ParentHash() != curKeyblock.Hash() {
 		//log.Error("verifyKeyBlock", "Non contiguous consensus prevhash", keyblock.ParentHash(), "currenthash", curKeyblock.Hash())
 		return fmt.Errorf("verifyKeyBlock,Non contiguous key block's hash")
+	}
+	if err := checkKeyBlockMinInterval(curKeyblock); err != nil {
+		return err
 	}
 	if keyblock.T_Number() != keyS.bc.CurrentBlockN() {
 		return fmt.Errorf("verifyKeyBlock, T_Number is not current, cur tx number:%d, k_t_number:%d", keyS.bc.CurrentBlockN(), keyblock.T_Number())

--- a/reconfig/service.go
+++ b/reconfig/service.go
@@ -319,17 +319,18 @@ func (s *Service) Propose() (e error, kState []byte, tState []byte, extra []byte
 
 	fixedMode := s.keyService.config != nil && (s.keyService.config.FixedLeader || s.keyService.config.FixedCommittee)
 	forceFixedTimedKeyBlock := false
-	if fixedMode && noDone {
-		curKeyBlock := s.kbc.CurrentBlock()
-		if curKeyBlock != nil {
-			lastKeyTime := time.Unix(int64(curKeyBlock.Time()), 0)
-			if time.Since(lastKeyTime) >= fixedModeKeyBlockInterval {
-				forceFixedTimedKeyBlock = true
-				log.Warn("Propose force fixed-mode timed keyblock", "elapsed", time.Since(lastKeyTime), "keyNumber", curKeyBlock.NumberU64(), "txNumber", s.bc.CurrentBlockN())
-			}
+	keyBlockIntervalElapsed := false
+	curKeyBlock := s.kbc.CurrentBlock()
+	if curKeyBlock != nil {
+		lastKeyTime := time.Unix(int64(curKeyBlock.Time()), 0)
+		elapsed := time.Since(lastKeyTime)
+		keyBlockIntervalElapsed = elapsed >= params.KeyBlockMinInterval
+		if fixedMode && noDone && elapsed >= fixedModeKeyBlockInterval {
+			forceFixedTimedKeyBlock = true
+			log.Warn("Propose force fixed-mode timed keyblock", "elapsed", elapsed, "keyNumber", curKeyBlock.NumberU64(), "txNumber", s.bc.CurrentBlockN())
 		}
 	}
-	shouldProposeKeyBlock := leaderIndex > 0 || (fixedMode && (!noDone || forceFixedTimedKeyBlock))
+	shouldProposeKeyBlock := keyBlockIntervalElapsed && (leaderIndex > 0 || (fixedMode && (!noDone || forceFixedTimedKeyBlock)))
 	if shouldProposeKeyBlock {
 		isDoneKeyBlock := !noDone || forceFixedTimedKeyBlock
 		keyblock, mb, bestCandi, err := s.keyService.tryProposalChangeCommittee(leaderIndex, isDoneKeyBlock)


### PR DESCRIPTION
### Motivation

- Prevent rapid consecutive keyblock creation/acceptance when many common miners are present by enforcing a minimum interval between keyblocks.
- Provide a defensive, two-layer protection so both proposers and verifiers (and miner candidate timestamps) respect the same minimum interval.

### Description

- Add a shared protocol constant `KeyBlockMinInterval = 10 * time.Minute` in `params/protocol_params.go` to centralize the minimum keyblock interval.
- Clamp miner PoW candidate timestamps to at least `parent keyblock time + KeyBlockMinInterval` and assign the computed value to `candidate.KeyCandidate.Time` in `miner/worker.go` before preparing work.
- Require the proposer to wait until `params.KeyBlockMinInterval` has elapsed since the last keyblock before attempting a keyblock proposal (updates in `reconfig/service.go`); the fixed-mode timed keyblock logic uses the same elapsed calculation.
- Add verification logic in `reconfig/keyblock.go` to reject incoming keyblocks whose `Time` is earlier than `parent keyblock time + KeyBlockMinInterval`, applied on both leader/local and normal verification paths.

Files changed: `params/protocol_params.go`, `miner/worker.go`, `reconfig/service.go`, `reconfig/keyblock.go`.

### Testing

- Ran `gofmt`/formatting checks and `git diff --check` to ensure the edited files are formatted and have no diff-check issues, which passed after fixes.
- Ran `GO111MODULE=off GOPATH=/tmp/cypher-gopath go test ./params`, which completed (no package test files to run).
- Attempted `GO111MODULE=off GOPATH=/tmp/cypher-gopath go test ./miner ./reconfig`, which failed to execute due to missing vendored/GOPATH dependencies in the execution environment (e.g. `github.com/VictoriaMetrics/fastcache`, `github.com/shirou/gopsutil/cpu`, `golang.org/x/sys/*`), so full package tests could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a092d89a21883309799d7e30cdfdcac)