### PR TITLE
Add fixed-mode UDP PoW result broadcast/listener and integrate with miner and candidate pool

### DIFF
--- a/core/candidate_pool.go
+++ b/core/candidate_pool.go
@@ -286,6 +286,7 @@ type CandidatePool struct {
 	mux            *event.TypeMux
 	db             ethdb.Database
 	CheckMinerPort func(addr string, blockN uint64, keyblockN uint64)
+	powResultUDP  *powResultUDPServer
 }
 
 // Backend wraps all methods required for candidate pool.

--- a/core/pow_result_udp.go
+++ b/core/pow_result_udp.go
@@ -1,0 +1,167 @@
+package core
+
+import (
+	"errors"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/cypherium/cypher/core/types"
+	"github.com/cypherium/cypher/log"
+	"github.com/cypherium/cypher/reconfig/bftview"
+	"github.com/cypherium/cypher/rlp"
+)
+
+const powResultUDPMaxPacketSize = 4096
+
+// PoWResultUDPPort derives the fixed-mode PoW result UDP port from the
+// consensus UDP port. Keeping it separate avoids colliding with the rnet
+// protocol already bound to RnetPort.
+func PoWResultUDPPort(rnetPort string) (int, error) {
+	port, err := strconv.Atoi(rnetPort)
+	if err != nil {
+		return 0, err
+	}
+	return port + 1, nil
+}
+
+// BroadcastPoWResultUDP broadcasts a mined PoW result to validators over UDP.
+func BroadcastPoWResultUDP(rnetPort string, result *types.PoWResult) error {
+	if result == nil {
+		return errors.New("nil pow result")
+	}
+	port, err := PoWResultUDPPort(rnetPort)
+	if err != nil {
+		return err
+	}
+	payload, err := rlp.EncodeToBytes(result)
+	if err != nil {
+		return err
+	}
+	if len(payload) > powResultUDPMaxPacketSize {
+		return errors.New("pow result UDP payload too large")
+	}
+
+	var firstErr error
+	for _, ip := range []net.IP{net.IPv4bcast, net.IPv4(127, 0, 0, 1)} {
+		addr := &net.UDPAddr{IP: ip, Port: port}
+		conn, err := net.DialUDP("udp4", nil, addr)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		_, err = conn.Write(payload)
+		conn.Close()
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+type powResultUDPServer struct {
+	conn net.PacketConn
+	once sync.Once
+}
+
+func (s *powResultUDPServer) stop() {
+	s.once.Do(func() {
+		if s.conn != nil {
+			s.conn.Close()
+		}
+	})
+}
+
+// StartPoWResultUDP starts the fixed-mode UDP listener that accepts compact PoW
+// results from miners, reconstructs candidates, verifies them locally and adds
+// the verified candidate to the pool for keyblock reward accounting.
+func (cp *CandidatePool) StartPoWResultUDP(rnetPort string) error {
+	port, err := PoWResultUDPPort(rnetPort)
+	if err != nil {
+		return err
+	}
+	addr := ":" + strconv.Itoa(port)
+	conn, err := net.ListenPacket("udp4", addr)
+	if err != nil {
+		return err
+	}
+	cp.powResultUDP = &powResultUDPServer{conn: conn}
+	go cp.powResultUDPLoop(conn)
+	log.Info("Started fixed-mode PoW result UDP listener", "addr", addr)
+	return nil
+}
+
+// StopPoWResultUDP stops the fixed-mode PoW result UDP listener, if present.
+func (cp *CandidatePool) StopPoWResultUDP() {
+	cp.mu.Lock()
+	server := cp.powResultUDP
+	cp.powResultUDP = nil
+	cp.mu.Unlock()
+	if server != nil {
+		server.stop()
+	}
+}
+
+func (cp *CandidatePool) powResultUDPLoop(conn net.PacketConn) {
+	buf := make([]byte, powResultUDPMaxPacketSize)
+	for {
+		n, from, err := conn.ReadFrom(buf)
+		if err != nil {
+			return
+		}
+		var result types.PoWResult
+		if err := rlp.DecodeBytes(buf[:n], &result); err != nil {
+			log.Warn("Failed to decode fixed-mode PoW result", "from", from, "err", err)
+			continue
+		}
+		if err := cp.AddRemotePoWResult(&result); err != nil {
+			log.Warn("Rejected fixed-mode PoW result", "from", from, "err", err)
+		}
+	}
+}
+
+// AddRemotePoWResult reconstructs and verifies a UDP PoW result without asking
+// the miner to participate in CandidatePool or block/keyblock validation.
+func (cp *CandidatePool) AddRemotePoWResult(result *types.PoWResult) error {
+	candidate := result.ToCandidate()
+	if candidate == nil || candidate.KeyCandidate == nil {
+		return errors.New("nil pow result candidate")
+	}
+	if bftview.GetMemberIndex(candidate.PubKey) >= 0 {
+		return ErrCandidateIsMember
+	}
+
+	keyBlock := cp.backend.KeyBlockChain().CurrentBlock()
+	if keyBlock == nil {
+		return types.ErrUnknownAncestor
+	}
+	if candidate.KeyCandidate.ParentHash != keyBlock.Hash() || candidate.KeyCandidate.Number.Uint64() != keyBlock.NumberU64()+1 {
+		return ErrCandidateNumberLow
+	}
+	if candidate.KeyCandidate.T_Number < keyBlock.T_Number() || candidate.KeyCandidate.T_Number > cp.backend.BlockChain().CurrentBlockN() {
+		return errors.New("pow result tx block number is outside the local work range")
+	}
+	if time.Since(time.Unix(int64(candidate.KeyCandidate.Time), 0)) > 2*time.Hour {
+		return errors.New("pow result is stale")
+	}
+
+	committeeSize := len(cp.backend.KeyBlockChain().CurrentCommittee())
+	if err := cp.backend.Engine().PrepareCandidate(cp.backend.KeyBlockChain(), candidate, committeeSize); err != nil {
+		return err
+	}
+	if err := cp.verify(candidate); err != nil {
+		return err
+	}
+
+	cp.mu.Lock()
+	defer cp.mu.Unlock()
+	if exists := cp.candidates.Add(candidate); exists {
+		return ErrCandidateExisted
+	}
+	log.Info("Accepted fixed-mode UDP PoW result", "candidate.number", candidate.KeyCandidate.Number.Uint64(), "pubkey", candidate.PubKey, "hash", candidate.Hash())
+	go cp.feed.Send(candidate)
+	return nil
+}

--- a/core/types/pow_result.go
+++ b/core/types/pow_result.go
@@ -1,0 +1,61 @@
+package types
+
+import (
+	"math/big"
+
+	"github.com/cypherium/cypher/common"
+)
+
+// PoWResult is the compact, UDP-friendly representation of a mined candidate
+// seal. It carries the work template identifiers and the PoW output only; a
+// validator reconstructs the Candidate locally and performs full verification.
+type PoWResult struct {
+	ParentHash common.Hash
+	Number     uint64
+	TNumber    uint64
+	Time       uint64
+
+	IP       []byte
+	Port     int
+	PubKey   string
+	Coinbase string
+
+	Nonce     BlockNonce
+	MixDigest common.Hash
+}
+
+// NewPoWResultFromCandidate extracts the mined PoW result and the minimal work
+// template metadata required by validators to reconstruct and verify it.
+func NewPoWResultFromCandidate(candidate *Candidate) *PoWResult {
+	if candidate == nil || candidate.KeyCandidate == nil {
+		return nil
+	}
+	result := &PoWResult{
+		ParentHash: candidate.KeyCandidate.ParentHash,
+		Number:     candidate.KeyCandidate.Number.Uint64(),
+		TNumber:    candidate.KeyCandidate.T_Number,
+		Time:       candidate.KeyCandidate.Time,
+		Port:       candidate.Port,
+		PubKey:     candidate.PubKey,
+		Coinbase:   candidate.Coinbase,
+		Nonce:      candidate.KeyCandidate.Nonce,
+		MixDigest:  candidate.KeyCandidate.MixDigest,
+	}
+	result.IP = make([]byte, len(candidate.IP))
+	copy(result.IP, candidate.IP)
+	return result
+}
+
+// ToCandidate reconstructs a Candidate from the PoW result. The difficulty is
+// intentionally left empty because validators recompute it from their local
+// chain state before verification.
+func (r *PoWResult) ToCandidate() *Candidate {
+	if r == nil {
+		return nil
+	}
+	candidate := NewCandidate(r.ParentHash, big.NewInt(0), r.Number, r.TNumber, nil, r.IP, r.PubKey, r.Coinbase, r.Port)
+	candidate.KeyCandidate.Time = r.Time
+	candidate.KeyCandidate.Nonce = r.Nonce
+	candidate.KeyCandidate.MixDigest = r.MixDigest
+	return candidate
+}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -235,6 +235,11 @@ func New(stack *node.Node, config *Config) (*Ethereum, error) {
 	if eth.protocolManager, err = NewProtocolManager(chainConfig, checkpoint, config.SyncMode, config.NetworkId, eth.eventMux, eth.txPool, eth.engine, eth.blockchain, chainDb, cacheLimit, config.Whitelist, eth.candidatePool); err != nil {
 		return nil, err
 	}
+	if chainConfig != nil && (chainConfig.FixedLeader || chainConfig.FixedCommittee) {
+		if err := eth.candidatePool.StartPoWResultUDP(chainConfig.RnetPort); err != nil {
+			return nil, err
+		}
+	}
 
 	//eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner = miner.New(eth, chainConfig, eth.EventMux(), eth.engine, extIP)
@@ -592,6 +597,7 @@ func (s *Ethereum) Start() error {
 func (s *Ethereum) Stop() error {
 	// Stop all the peer-related stuff first.
 	s.protocolManager.Stop()
+	s.candidatePool.StopPoWResultUDP()
 
 	// Then stop everything else.
 	s.bloomIndexer.Close()

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -99,6 +99,8 @@ type ProtocolManager struct {
 	wg        sync.WaitGroup
 	peerWG    sync.WaitGroup
 
+	chainConfig *params.ChainConfig
+
 	// Test fields or hooks
 	broadcastTxAnnouncesOnly bool // Testing field, disable transaction propagation
 }
@@ -117,6 +119,7 @@ func NewProtocolManager(config *params.ChainConfig, checkpoint *params.TrustedCh
 		chaindb:       chaindb,
 		peers:         newPeerSet(),
 		whitelist:     whitelist,
+		chainConfig:   config,
 		txsyncCh:      make(chan *txsync),
 		quitSync:      make(chan struct{}),
 	}
@@ -946,6 +949,10 @@ func (pm *ProtocolManager) txBroadcastLoop() {
 }
 
 func (pm *ProtocolManager) BroadcastCandidate(candidate *types.Candidate) {
+	if pm.chainConfig != nil && (pm.chainConfig.FixedLeader || pm.chainConfig.FixedCommittee) {
+		log.Trace("Skip candidate p2p broadcast in fixed mode", "candidate.hash", candidate.Hash())
+		return
+	}
 	// Broadcast pow candidate to a batch of peers not knowing about it
 	peers := pm.peers.PeersWithoutCandidate(candidate.Hash())
 	for _, peer := range peers {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -235,6 +235,13 @@ func (self *worker) wait() {
 				continue
 			}
 
+			if self.config != nil && (self.config.FixedLeader || self.config.FixedCommittee) {
+				if err := core.BroadcastPoWResultUDP(self.config.RnetPort, types.NewPoWResultFromCandidate(candidate)); err != nil {
+					log.Error("Fail to broadcast fixed-mode PoW result", "err", err)
+				}
+				continue
+			}
+
 			if err := self.candidatePool.AddLocal(candidate); err != nil {
 				log.Error("Fail to add local candidate", "err", err)
 				if err != core.ErrCandidateExisted && err != core.ErrCandidateIsMember {


### PR DESCRIPTION
### Motivation

- Enable a fixed-mode (fixed leader / fixed committee) fast path where miners broadcast compact PoW results over UDP so validators can reconstruct and verify candidates locally.
- Avoid P2P candidate propagation in fixed-mode and instead rely on a lightweight UDP-based distribution for PoW results.

### Description

- Introduces a compact `types.PoWResult` and conversion helpers `NewPoWResultFromCandidate` and `ToCandidate` for UDP-friendly sealed candidate representation.
- Adds UDP broadcast and listener logic in `core/pow_result_udp.go`, exposing `BroadcastPoWResultUDP`, and `CandidatePool` methods `StartPoWResultUDP`, `StopPoWResultUDP`, `AddRemotePoWResult` plus an internal `powResultUDPServer` and receive loop to decode, reconstruct and verify incoming PoW results before inserting them into the pool.
- Extends `CandidatePool` with a `powResultUDP` field and wires lifecycle start/stop: the backend now starts the UDP listener when `chainConfig.FixedLeader` or `chainConfig.FixedCommittee` are enabled, and stops it on shutdown via `CandidatePool.StopPoWResultUDP`.
- Changes miner `worker.wait` to broadcast a `PoWResult` over UDP with `BroadcastPoWResultUDP` instead of adding candidates to the pool when running in fixed-mode (`config.FixedLeader || config.FixedCommittee`).
- Adds `chainConfig` to `ProtocolManager` and skips P2P candidate broadcasts in fixed-mode by returning early from `BroadcastCandidate`.

### Testing

- Ran unit tests with `go test ./...` which completed successfully.
- Ran static checks (build) to ensure UDP listener and integration compile and the new symbols are linked correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0961a038688330b672d9631b2b89ee)