### PR TITLE
Populate `miner` in RPC block output from corresponding KeyBlock

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1339,6 +1339,9 @@ func (s *PublicBlockChainAPI) rpcMarshalBlock(ctx context.Context, b *types.Bloc
 	if err != nil {
 		return nil, err
 	}
+	if keyblock, keyErr := s.b.KeyBlockByHash(ctx, b.KeyHash()); keyErr == nil && keyblock != nil {
+		fields["miner"] = keyblock.OutAddress(1)
+	}
 	if inclTx {
 		fields["totalDifficulty"] = (*hexutil.Big)(s.b.GetTd(ctx, b.Hash()))
 	}


### PR DESCRIPTION
### Motivation
- Ensure RPC block responses include the correct `miner` address derived from the associated key block when one exists, so block listings reflect the key-block-defined miner output.

### Description
- In `rpcMarshalBlock` call `s.b.KeyBlockByHash(ctx, b.KeyHash())` and, if present, set `fields["miner"] = keyblock.OutAddress(1)` while keeping the existing `totalDifficulty` handling intact.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cc3bb30008330b50083f76ad82c34)