### PR TITLE
eth: honor miner start threads

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -26,7 +26,7 @@ import (
 	"net"
 	"os"
 
-	//	"runtime"
+	"runtime"
 	"strings"
 
 	"github.com/cypherium/cypher/common"
@@ -151,6 +151,15 @@ func (api *PrivateMinerAPI) Start(threads *int) error {
 
 */
 func (api *PrivateMinerAPI) Start(threads *int, addr common.Address, password string) (string, error) {
+	miningThreads := runtime.NumCPU()
+	if threads != nil {
+		miningThreads = *threads
+	}
+	if api.e.IsMining() {
+		api.e.setMiningThreads(miningThreads)
+		return "Mining threads updated", nil
+	}
+
 	var (
 		err    error
 		eb     common.Address
@@ -158,10 +167,7 @@ func (api *PrivateMinerAPI) Start(threads *int, addr common.Address, password st
 		pubKey ed25519.PublicKey
 	)
 
-	if api.e.IsMining() {
-		return "Mining is already in progress", nil
-	}
-	//log.Info("miner.start", "threads", threads, "addr", addr, "passwd", password)
+	//log.Info("miner.start", "threads", miningThreads, "addr", addr, "passwd", password)
 
 	server := &common.NodeConfig{}
 
@@ -209,7 +215,7 @@ func (api *PrivateMinerAPI) Start(threads *int, addr common.Address, password st
 	//	log.Info("Updated mining threads", "threads", *threads)
 	//	th.SetThreads(*threads)
 	//}
-	if err := api.e.StartMining(true, eb, pubKey); err != nil {
+	if err := api.e.StartMining(miningThreads, true, eb, pubKey); err != nil {
 		return "", err
 	}
 	return "Mining started", nil

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -520,7 +520,20 @@ func (s *Ethereum) StopMining() {
 }
 */
 func (s *Ethereum) ServiceIsRunning() bool { return s.reconfig.ServiceIsRunning() }
-func (s *Ethereum) StartMining(local bool, eb common.Address, pubKey ed25519.PublicKey) error {
+
+func (s *Ethereum) setMiningThreads(threads int) {
+	type threaded interface {
+		SetThreads(threads int)
+	}
+	if th, ok := s.engine.(threaded); ok {
+		log.Info("Updated mining threads", "threads", threads)
+		th.SetThreads(threads)
+	}
+}
+
+func (s *Ethereum) StartMining(threads int, local bool, eb common.Address, pubKey ed25519.PublicKey) error {
+	s.setMiningThreads(threads)
+
 	// If the miner was not running, initialize it
 	if !s.IsMining() {
 		s.lock.RLock()


### PR DESCRIPTION
### Motivation

- The `miner.start` RPC accepted a thread count but did not propagate it into the node/runtime, so calling `miner.start(10, ...)` had no effect on consensus engines that support thread control. 
- The intent is to honor the requested thread count and allow updating the thread count while mining is already running.

### Description

- The private miner RPC now resolves the requested threads into `miningThreads` (defaulting to `runtime.NumCPU()`) and, if mining is already active, calls `setMiningThreads(miningThreads)` to update the engine thread count without restarting (`eth/api.go`).
- `Start` now forwards the resolved `miningThreads` into `StartMining(miningThreads, ...)` instead of ignoring the parameter, so the startup path receives the requested value (`eth/api.go`).
- Added `setMiningThreads(threads int)` helper and changed `StartMining` to accept a `threads int` parameter; `setMiningThreads` calls `SetThreads` on the consensus engine when it implements that interface, and `StartMining` invokes this helper before starting the miner (`eth/backend.go`).
- Imported `runtime` (for `runtime.NumCPU()`), applied formatting, and kept existing reconfiguration/coinbase logic intact.

### Testing

- Ran `gofmt -w eth/api.go` to format the changed file and `git diff --check` to ensure no whitespace/error diffs, both succeeded.
- Attempted `go test ./eth` in the repository root but the environment reported module/GOPATH path issues and could not run tests here. 
- Attempted `GOPATH=/tmp/cypher-gopath GO111MODULE=off go test github.com/cypherium/cypher/eth` but the run failed due to missing vendored/GOPATH dependencies (e.g. `golang.org/x/sys/cpu`, `github.com/VictoriaMetrics/fastcache`, `github.com/shirou/gopsutil/cpu`), so unit tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a187431724c833095abcf67d122da7c)