### PR TITLE
reconfig: align fixed-mode keyblock views

### DIFF
--- a/reconfig/service.go
+++ b/reconfig/service.go
@@ -779,18 +779,24 @@ func (s *Service) handleHotStuffMsg() {
 				pendingTotal, _ = s.txPool.Stats()
 			}
 			candidateRewardReady := s.fixedModeCandidateRewardReady(now)
+			keyblockIntervalElapsed := s.fixedModeKeyblockIntervalElapsed(now)
 
 			// Fixed-mode keyblock liveness:
 			// This must run on every committee member, not only the leader.
-			// Each member needs to send MsgNewView to the current leader; otherwise
-			// the leader only receives its own new-view vote and stays in PhasePrepare.
-			if s.fixedModeKeyblockIntervalElapsed(now) {
+			// Every member must first switch to the same keyblock view (NoDone=false)
+			// before sending MsgNewView. If only the leader flips NoDone, replicas vote
+			// for a different view hash and the leader never reaches the new-view quorum.
+			if keyblockIntervalElapsed {
 				if s.lastFixedKeyNewViewWakeup.IsZero() || now.Sub(s.lastFixedKeyNewViewWakeup) >= 2*time.Second {
 					s.lastFixedKeyNewViewWakeup = now
+					oldView := s.GetCurrentView()
+					s.setNextLeader(true)
 					curView := s.GetCurrentView()
 					log.Warn("fixed-mode keyblock start-new-view wakeup",
 						"currentBlock", s.bc.CurrentBlockN(),
 						"currentKey", s.kbc.CurrentBlockN(),
+						"oldLeaderIndex", oldView.LeaderIndex,
+						"oldNoDone", oldView.NoDone,
 						"leaderIndex", curView.LeaderIndex,
 						"noDone", curView.NoDone,
 						"isLeader", bftview.IamLeader(curView.LeaderIndex),
@@ -798,22 +804,14 @@ func (s *Service) handleHotStuffMsg() {
 						"pendingTotal", pendingTotal,
 						"fastPending", fastPending,
 						"slowPending", slowPending)
-					if bftview.IamLeader(curView.LeaderIndex) {
-						// force keyblock view before leader try-propose.
-						// In fixed mode Propose() uses !NoDone to select keyblock proposal.
-						s.setNextLeader(true)
-						log.Warn("fixed-mode keyblock due leader try-propose",
-							"currentBlock", s.bc.CurrentBlockN(),
-							"currentKey", s.kbc.CurrentBlockN(),
-							"leaderIndex", curView.LeaderIndex,
-							"noDone", curView.NoDone,
-							"candidateReady", candidateRewardReady,
-							"pendingTotal", pendingTotal)
-						s.triggerTryPropose(s.bc.CurrentBlockN())
-					} else {
-						s.sendNewViewMsg(s.bc.CurrentBlockN())
-					}
+					s.sendNewViewMsg(s.bc.CurrentBlockN())
 				}
+
+				// Keyblock interval has priority over tx/candidate liveness wakeups.
+				// Let MsgStartNewView drive HotStuff to PhaseTryPropose instead of
+				// enqueueing MsgTryPropose against a stale or nil leader view.
+				s.protocolMng.HandleMessage(&hotstuff.HotstuffMessage{Code: hotstuff.MsgTimer, Number: s.bc.CurrentBlockN()})
+				continue
 			}
 
 			// Fixed-mode liveness repair must run before IamLeader check.


### PR DESCRIPTION
### Motivation
- Fixed-mode keyblock liveness could deadlock: when the keyblock interval elapsed only the leader flipped into the keyblock view, replicas kept the old view hash and the leader could not collect a new-view quorum, causing repeated `TryPropose` attempts without producing key blocks.

### Description
- In `reconfig/service.go` compute `keyblockIntervalElapsed` and ensure committee members switch the local view to the keyblock view by calling `setNextLeader(true)` before sending `MsgStartNewView`.
- Replace the previous direct enqueueing of `MsgTryPropose` on interval expiry with sending `MsgStartNewView`/`MsgTimer` so HotStuff advances to `PhaseTryPropose` with a consistent leader view instead of proposing against a stale or nil leader view.
- Added logging of the previous view (leader index and `NoDone`) and simplified the leader vs replica handling to avoid mismatched view hashes during fixed-mode keyblock wakeups.

### Testing
- Ran `gofmt -w reconfig/service.go` and `git diff --check` with no formatting errors reported.
- Attempted `go test ./reconfig/...` but the repository root is not a Go module so the module-mode test run did not execute; running with `GO111MODULE=off` / GOPATH also failed due to missing vendored dependencies, therefore unit tests could not be executed in this environment.
- Performed static review of the HotStuff/new-view flow and verified the change restricts interval-driven wakeups to `MsgStartNewView` so `TryPropose()` is exercised only when a valid leader view exists.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e85e84a48330b8259da31070052d)