### PR TITLE
Use service-level verifier for common approval in OnPropose

### DIFF
--- a/reconfig/service.go
+++ b/reconfig/service.go
@@ -312,7 +312,7 @@ func (s *Service) OnPropose(state []byte, extra []byte) error { //verify new blo
 			log.Error("verify txblock", "number", block.NumberU64(), "err", err)
 			return err
 		}
-		if err := core.VerifyCommonApproval(s.chainConfig, block); err != nil {
+		if err := s.verifyCommonApprovalForBlock(block); err != nil {
 			log.Error("verify common approval", "number", block.NumberU64(), "err", err)
 			return err
 		}


### PR DESCRIPTION
### Motivation
- Centralize and contextualize common-approval verification so the reconfiguration `Service` can apply its own state or logic instead of calling the package-level `core` function directly.

### Description
- Replace the call to `core.VerifyCommonApproval(s.chainConfig, block)` with `s.verifyCommonApprovalForBlock(block)` in `reconfig/service.go` inside `OnPropose` to route verification through the service.
- Preserve existing error handling and logging behavior when verification fails.

### Testing
- Ran `go test ./reconfig` locally and the reconfig package tests passed. 
- Ran `go test ./...` and `go vet` locally with no failures reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21dddce3a08330b75e041d1ed1378e)