### PR TITLE
Fix fixed-mode keyblock liveness to force view switch and drive propose via MsgTimer

### DIFF
--- a/reconfig/service.go
+++ b/reconfig/service.go
@@ -788,18 +788,24 @@ func (s *Service) handleHotStuffMsg() {
 				pendingTotal, _ = s.txPool.Stats()
 			}
 			candidateRewardReady := s.fixedModeCandidateRewardReady(now)
+			keyblockIntervalElapsed := s.fixedModeKeyblockIntervalElapsed(now)
 
 			// Fixed-mode keyblock liveness:
 			// This must run on every committee member, not only the leader.
-			// Each member needs to send MsgNewView to the current leader; otherwise
-			// the leader only receives its own new-view vote and stays in PhasePrepare.
-			if s.fixedModeKeyblockIntervalElapsed(now) {
+			// Every member must first switch to the same keyblock view (NoDone=false)
+			// before sending MsgNewView. If only the leader flips NoDone, replicas vote
+			// for a different view hash and the leader never reaches the new-view quorum.
+			if keyblockIntervalElapsed {
 				if s.lastFixedKeyNewViewWakeup.IsZero() || now.Sub(s.lastFixedKeyNewViewWakeup) >= 2*time.Second {
 					s.lastFixedKeyNewViewWakeup = now
+					oldView := *s.GetCurrentView()
+					s.setNextLeader(true)
 					curView := s.GetCurrentView()
 					log.Warn("fixed-mode keyblock start-new-view wakeup",
 						"currentBlock", s.bc.CurrentBlockN(),
 						"currentKey", s.kbc.CurrentBlockN(),
+						"oldLeaderIndex", oldView.LeaderIndex,
+						"oldNoDone", oldView.NoDone,
 						"leaderIndex", curView.LeaderIndex,
 						"noDone", curView.NoDone,
 						"isLeader", bftview.IamLeader(curView.LeaderIndex),
@@ -807,22 +813,14 @@ func (s *Service) handleHotStuffMsg() {
 						"pendingTotal", pendingTotal,
 						"fastPending", fastPending,
 						"slowPending", slowPending)
-					if bftview.IamLeader(curView.LeaderIndex) {
-						// force keyblock view before leader try-propose.
-						// In fixed mode Propose() uses !NoDone to select keyblock proposal.
-						s.setNextLeader(true)
-						log.Warn("fixed-mode keyblock due leader try-propose",
-							"currentBlock", s.bc.CurrentBlockN(),
-							"currentKey", s.kbc.CurrentBlockN(),
-							"leaderIndex", curView.LeaderIndex,
-							"noDone", curView.NoDone,
-							"candidateReady", candidateRewardReady,
-							"pendingTotal", pendingTotal)
-						s.triggerTryPropose(s.bc.CurrentBlockN())
-					} else {
-						s.sendNewViewMsg(s.bc.CurrentBlockN())
-					}
+					s.sendNewViewMsg(s.bc.CurrentBlockN())
 				}
+
+				// Keyblock interval has priority over tx/candidate liveness wakeups.
+				// Let MsgStartNewView drive HotStuff to PhaseTryPropose instead of
+				// enqueueing MsgTryPropose against a stale or nil leader view.
+				s.protocolMng.HandleMessage(&hotstuff.HotstuffMessage{Code: hotstuff.MsgTimer, Number: s.bc.CurrentBlockN()})
+				continue
 			}
 
 			// Fixed-mode liveness repair must run before IamLeader check.


### PR DESCRIPTION
### Motivation

- Ensure fixed-mode keyblock liveness reliably advances the committee view by making every member flip the keyblock view (`NoDone=false`) before sending `MsgNewView`, avoiding a leader-only flip that prevents a new-view quorum. 
- Prevent stale leader proposals by prioritizing keyblock wakeups over tx/candidate liveness and driving HotStuff into `PhaseTryPropose` via a timed message rather than enqueueing a `MsgTryPropose` against a possibly stale view.

### Description

- Capture the keyblock interval condition in `keyblockIntervalElapsed` and use it to gate the fixed-mode keyblock wakeup path. 
- When the keyblock interval has elapsed update `lastFixedKeyNewViewWakeup`, snapshot the previous view (`oldView`), and call `s.setNextLeader(true)` before fetching the current view to ensure all members switch `NoDone` consistently. 
- Always call `s.sendNewViewMsg(s.bc.CurrentBlockN())` for the wakeup path and log `oldLeaderIndex` and `oldNoDone` for diagnostics. 
- Replace the prior leader-only `triggerTryPropose` branch with a call to `s.protocolMng.HandleMessage(&hotstuff.HotstuffMessage{Code: hotstuff.MsgTimer, Number: s.bc.CurrentBlockN()})` and `continue` to let `MsgTimer` drive HotStuff to `PhaseTryPropose` and to give keyblock interval priority over other liveness wakeups.

### Testing

- Built the service and ran unit tests with `go test ./...`, which completed successfully. 
- Verified the modified `handleHotStuffMsg` path executes without build errors during local integration smoke runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21f7c8088c83309277c26d0f5b8c2a)