### PR TITLE
reconfig: reward active common approval committee

### DIFF
--- a/reconfig/common_approval_rewards.go
+++ b/reconfig/common_approval_rewards.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cypherium/cypher/core"
 	"github.com/cypherium/cypher/core/types"
 	"github.com/cypherium/cypher/log"
+	"github.com/cypherium/cypher/params"
 )
 
 func (keyS *keyService) buildCommonApprovalRewardSummary(fromN, toN uint64) ([]types.CommonApprovalReward, error) {
@@ -16,12 +17,9 @@ func (keyS *keyService) buildCommonApprovalRewardSummary(fromN, toN uint64) ([]t
 		return nil, nil
 	}
 
-	nodes := core.OrderedCommonCommittee(keyS.config)
-	if len(nodes) == 0 {
-		return nil, nil
-	}
-	committeeHash := core.CommonApprovalCommitteeHash(keyS.config)
 	counts := make(map[string]uint64)
+	orderedCoinBases := make([]string, 0)
+	seenCoinBases := make(map[string]struct{})
 
 	for n := fromN; n <= toN; n++ {
 		block := keyS.bc.GetBlockByNumber(n)
@@ -31,47 +29,75 @@ func (keyS *keyService) buildCommonApprovalRewardSummary(fromN, toN uint64) ([]t
 		if !core.CommonApprovalRequired(keyS.config, block) {
 			continue
 		}
-		si := block.SignInfo()
-		if si == nil || len(si.CommonApprovalSignature) == 0 || len(si.CommonApprovalExceptions) == 0 {
+
+		var keyblock *types.KeyBlock
+		if keyS.kbc != nil {
+			keyblock = keyS.kbc.GetBlockByHash(block.KeyHash())
+		}
+		rewards := commonApprovalRewardsForBlock(keyS.config, block, keyblock)
+		if rewards == nil {
+			nodes := core.OrderedCommonCommitteeForKeyBlock(keyS.config, keyblock)
+			committeeHash := core.CommonApprovalCommitteeHashFromNodes(nodes)
+			si := block.SignInfo()
+			if si != nil && len(si.CommonApprovalSignature) > 0 && len(si.CommonApprovalExceptions) > 0 && si.CommonApprovalCommitteeHash != committeeHash {
+				log.Warn("skip common approval reward summary: committee hash mismatch",
+					"block", block.NumberU64(),
+					"keyHash", block.KeyHash(),
+					"have", si.CommonApprovalCommitteeHash.Hex(),
+					"want", committeeHash.Hex())
+			}
 			continue
 		}
-		if si.CommonApprovalCommitteeHash != committeeHash {
-			log.Warn("skip common approval reward summary: committee hash mismatch",
-				"block", block.NumberU64(),
-				"have", si.CommonApprovalCommitteeHash.Hex(),
-				"want", committeeHash.Hex())
-			continue
-		}
-		mask := si.CommonApprovalExceptions
-		for i, node := range nodes {
-			if node == nil || node.CoinBase == "" {
-				continue
+		for _, reward := range rewards {
+			if _, ok := seenCoinBases[reward.CoinBase]; !ok {
+				orderedCoinBases = append(orderedCoinBases, reward.CoinBase)
+				seenCoinBases[reward.CoinBase] = struct{}{}
 			}
-			if len(mask) <= i/8 {
-				continue
-			}
-			if (mask[i/8] & (1 << uint(i%8))) == 0 {
-				continue
-			}
-			counts[node.CoinBase]++
+			counts[reward.CoinBase] += reward.SignedTxBlocks
 		}
 	}
 
 	rewards := make([]types.CommonApprovalReward, 0, len(counts))
-	for _, node := range nodes {
-		if node == nil || node.CoinBase == "" {
+	for _, coinBase := range orderedCoinBases {
+		rewards = append(rewards, types.CommonApprovalReward{
+			CoinBase:       coinBase,
+			SignedTxBlocks: counts[coinBase],
+		})
+	}
+	return rewards, nil
+}
+
+// commonApprovalRewardsForBlock resolves signer mask indexes against the active
+// common committee recorded in the KeyBlock referenced by the tx block. The
+// config committee is only a compatibility fallback for old KeyBlocks without
+// an ActiveCommonCommittee snapshot.
+func commonApprovalRewardsForBlock(config *params.ChainConfig, block *types.Block, keyblock *types.KeyBlock) []types.CommonApprovalReward {
+	if !core.CommonApprovalRequired(config, block) {
+		return nil
+	}
+	si := block.SignInfo()
+	if si == nil || len(si.CommonApprovalSignature) == 0 || len(si.CommonApprovalExceptions) == 0 {
+		return nil
+	}
+	nodes := core.OrderedCommonCommitteeForKeyBlock(config, keyblock)
+	if len(nodes) == 0 || si.CommonApprovalCommitteeHash != core.CommonApprovalCommitteeHashFromNodes(nodes) {
+		return nil
+	}
+
+	rewards := make([]types.CommonApprovalReward, 0, len(nodes))
+	for i, node := range nodes {
+		if node == nil || node.CoinBase == "" || len(si.CommonApprovalExceptions) <= i/8 {
 			continue
 		}
-		count := counts[node.CoinBase]
-		if count == 0 {
+		if (si.CommonApprovalExceptions[i/8] & (1 << uint(i%8))) == 0 {
 			continue
 		}
 		rewards = append(rewards, types.CommonApprovalReward{
 			CoinBase:       node.CoinBase,
-			SignedTxBlocks: count,
+			SignedTxBlocks: 1,
 		})
 	}
-	return rewards, nil
+	return rewards
 }
 
 func (keyS *keyService) verifyCommonApprovalRewardSummary(keyblock *types.KeyBlock, fromN, toN uint64) error {

--- a/reconfig/common_approval_rewards_test.go
+++ b/reconfig/common_approval_rewards_test.go
@@ -1,0 +1,106 @@
+package reconfig
+
+import (
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/cypherium/cypher/common"
+	"github.com/cypherium/cypher/core"
+	"github.com/cypherium/cypher/core/types"
+	"github.com/cypherium/cypher/params"
+)
+
+func TestCommonApprovalRewardsUseKeyBlockActiveCommittee(t *testing.T) {
+	bootstrap := common.Cnode{
+		Address:  "bootstrap-address",
+		CoinBase: "0x0000000000000000000000000000000000000001",
+		Public:   "bootstrap-public",
+	}
+	dynamic := common.Cnode{
+		Address:  "dynamic-address",
+		CoinBase: "0x0000000000000000000000000000000000000002",
+		Public:   "dynamic-public",
+	}
+	config := &params.ChainConfig{
+		CommonApprovalEnabled: true,
+		CommonCommittee: params.GenesisCommittee{
+			core.CommonApprovalBootstrapIndex: bootstrap,
+		},
+	}
+	keyblock := types.NewKeyBlock(&types.KeyBlockHeader{
+		Difficulty: big.NewInt(1),
+		Number:     big.NewInt(1),
+	})
+	keyblock.SetActiveCommonCommittee([]types.CommonApprovalCommitteeMember{
+		{Address: bootstrap.Address, CoinBase: bootstrap.CoinBase, Public: bootstrap.Public},
+		{Address: dynamic.Address, CoinBase: dynamic.CoinBase, Public: dynamic.Public},
+	})
+	activeNodes := core.OrderedCommonCommitteeForKeyBlock(config, keyblock)
+	activeHash := core.CommonApprovalCommitteeHashFromNodes(activeNodes)
+	if activeHash == core.CommonApprovalCommitteeHash(config) {
+		t.Fatal("test requires the active committee hash to differ from the config fallback")
+	}
+
+	block := types.NewBlockWithHeader(&types.Header{
+		Difficulty: big.NewInt(1),
+		Number:     big.NewInt(1),
+		BlockType:  types.FastTx_Block,
+		KeyHash:    keyblock.Hash(),
+		SignInfo: types.SignInfo{
+			CommonApprovalSignature:     []byte{1},
+			CommonApprovalExceptions:    []byte{0x03},
+			CommonApprovalCommitteeHash: activeHash,
+		},
+	})
+
+	got := commonApprovalRewardsForBlock(config, block, keyblock)
+	want := []types.CommonApprovalReward{
+		{CoinBase: common.HexToAddress(bootstrap.CoinBase).Hex(), SignedTxBlocks: 1},
+		{CoinBase: common.HexToAddress(dynamic.CoinBase).Hex(), SignedTxBlocks: 1},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected rewards: have=%v want=%v", got, want)
+	}
+}
+
+func TestCommonApprovalRewardsHonorActiveCommitteeSignerMask(t *testing.T) {
+	bootstrap := common.Cnode{
+		Address:  "bootstrap-address",
+		CoinBase: "0x0000000000000000000000000000000000000011",
+		Public:   "bootstrap-public",
+	}
+	dynamic := common.Cnode{
+		Address:  "dynamic-address",
+		CoinBase: "0x0000000000000000000000000000000000000012",
+		Public:   "dynamic-public",
+	}
+	config := &params.ChainConfig{
+		CommonApprovalEnabled: true,
+		CommonCommittee: params.GenesisCommittee{
+			core.CommonApprovalBootstrapIndex: bootstrap,
+		},
+	}
+	keyblock := types.NewKeyBlock(&types.KeyBlockHeader{Difficulty: big.NewInt(1), Number: big.NewInt(1)})
+	keyblock.SetActiveCommonCommittee([]types.CommonApprovalCommitteeMember{
+		{Address: bootstrap.Address, CoinBase: bootstrap.CoinBase, Public: bootstrap.Public},
+		{Address: dynamic.Address, CoinBase: dynamic.CoinBase, Public: dynamic.Public},
+	})
+	activeHash := core.CommonApprovalCommitteeHashForKeyBlock(config, keyblock)
+	block := types.NewBlockWithHeader(&types.Header{
+		Difficulty: big.NewInt(1),
+		Number:     big.NewInt(1),
+		BlockType:  types.FastTx_Block,
+		SignInfo: types.SignInfo{
+			CommonApprovalSignature:     []byte{1},
+			CommonApprovalExceptions:    []byte{0x02},
+			CommonApprovalCommitteeHash: activeHash,
+		},
+	})
+
+	got := commonApprovalRewardsForBlock(config, block, keyblock)
+	want := []types.CommonApprovalReward{{CoinBase: common.HexToAddress(dynamic.CoinBase).Hex(), SignedTxBlocks: 1}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected rewards: have=%v want=%v", got, want)
+	}
+}


### PR DESCRIPTION
### Motivation
- Reward summary construction used the static genesis/config `CommonCommittee` instead of the KeyBlock snapshot `ActiveCommonCommittee`, causing approved TxBlocks to be skipped when the active committee differed and resulting in missing CommonApproval rewards.
- The intent is to ensure rewards are credited based on the same committee snapshot that was used to verify/sign the TxBlock so the KeyBlock stores a correct `CommonApprovalRewards` summary.

### Description
- Change `buildCommonApprovalRewardSummary` to resolve each TxBlock's referenced KeyBlock and compute rewards using the KeyBlock's `ActiveCommonCommittee` when present, falling back to the config genesis committee only for legacy KeyBlocks.
- Add `commonApprovalRewardsForBlock(config *params.ChainConfig, block *types.Block, keyblock *types.KeyBlock)` which maps signer-mask bits to the active committee members and returns per-block reward entries.
- Preserve deterministic ordering when aggregating per-coinbase signer counts so the generated KeyBlock summary is stable across nodes.
- Add unit tests (`reconfig/common_approval_rewards_test.go`) that cover a two-member active committee (bootstrap + dynamic member) and validate signer-mask filtering behavior.

### Testing
- Ran formatting with `gofmt -w` on the modified files (success).
- Ran local static checks (`git diff --check`) (no issues found).
- Added unit tests under `reconfig/` for the active-committee reward resolution, but a full `go test` run in this environment could not complete due to missing vendored dependencies and inability to download modules from the proxy (network/proxy restrictions caused fetch errors), so the new tests were not executed end-to-end here.
- All code changes were formatted and static-checked; the new tests are self-contained and should pass in a normal developer environment with the repository vendor or module download access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2269e014d08330b17b1a14f85be5f7)