### PR TITLE
Use KeyBlock active common committee when building common approval reward summary and add unit tests

### DIFF
--- a/reconfig/common_approval_rewards.go
+++ b/reconfig/common_approval_rewards.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cypherium/cypher/core"
 	"github.com/cypherium/cypher/core/types"
 	"github.com/cypherium/cypher/log"
+	"github.com/cypherium/cypher/params"
 )
 
 func (keyS *keyService) buildCommonApprovalRewardSummary(fromN, toN uint64) ([]types.CommonApprovalReward, error) {
@@ -16,12 +17,9 @@ func (keyS *keyService) buildCommonApprovalRewardSummary(fromN, toN uint64) ([]t
 		return nil, nil
 	}
 
-	nodes := core.OrderedCommonCommittee(keyS.config)
-	if len(nodes) == 0 {
-		return nil, nil
-	}
-	committeeHash := core.CommonApprovalCommitteeHash(keyS.config)
 	counts := make(map[string]uint64)
+	orderedCoinBases := make([]string, 0)
+	seenCoinBases := make(map[string]struct{})
 
 	for n := fromN; n <= toN; n++ {
 		block := keyS.bc.GetBlockByNumber(n)
@@ -31,47 +29,75 @@ func (keyS *keyService) buildCommonApprovalRewardSummary(fromN, toN uint64) ([]t
 		if !core.CommonApprovalRequired(keyS.config, block) {
 			continue
 		}
-		si := block.SignInfo()
-		if si == nil || len(si.CommonApprovalSignature) == 0 || len(si.CommonApprovalExceptions) == 0 {
+
+		var keyblock *types.KeyBlock
+		if keyS.kbc != nil {
+			keyblock = keyS.kbc.GetBlockByHash(block.KeyHash())
+		}
+		rewards := commonApprovalRewardsForBlock(keyS.config, block, keyblock)
+		if rewards == nil {
+			nodes := core.OrderedCommonCommitteeForKeyBlock(keyS.config, keyblock)
+			committeeHash := core.CommonApprovalCommitteeHashFromNodes(nodes)
+			si := block.SignInfo()
+			if si != nil && len(si.CommonApprovalSignature) > 0 && len(si.CommonApprovalExceptions) > 0 && si.CommonApprovalCommitteeHash != committeeHash {
+				log.Warn("skip common approval reward summary: committee hash mismatch",
+					"block", block.NumberU64(),
+					"keyHash", block.KeyHash(),
+					"have", si.CommonApprovalCommitteeHash.Hex(),
+					"want", committeeHash.Hex())
+			}
 			continue
 		}
-		if si.CommonApprovalCommitteeHash != committeeHash {
-			log.Warn("skip common approval reward summary: committee hash mismatch",
-				"block", block.NumberU64(),
-				"have", si.CommonApprovalCommitteeHash.Hex(),
-				"want", committeeHash.Hex())
-			continue
-		}
-		mask := si.CommonApprovalExceptions
-		for i, node := range nodes {
-			if node == nil || node.CoinBase == "" {
-				continue
+		for _, reward := range rewards {
+			if _, ok := seenCoinBases[reward.CoinBase]; !ok {
+				orderedCoinBases = append(orderedCoinBases, reward.CoinBase)
+				seenCoinBases[reward.CoinBase] = struct{}{}
 			}
-			if len(mask) <= i/8 {
-				continue
-			}
-			if (mask[i/8] & (1 << uint(i%8))) == 0 {
-				continue
-			}
-			counts[node.CoinBase]++
+			counts[reward.CoinBase] += reward.SignedTxBlocks
 		}
 	}
 
 	rewards := make([]types.CommonApprovalReward, 0, len(counts))
-	for _, node := range nodes {
-		if node == nil || node.CoinBase == "" {
+	for _, coinBase := range orderedCoinBases {
+		rewards = append(rewards, types.CommonApprovalReward{
+			CoinBase:       coinBase,
+			SignedTxBlocks: counts[coinBase],
+		})
+	}
+	return rewards, nil
+}
+
+// commonApprovalRewardsForBlock resolves signer mask indexes against the active
+// common committee recorded in the KeyBlock referenced by the tx block. The
+// config committee is only a compatibility fallback for old KeyBlocks without
+// an ActiveCommonCommittee snapshot.
+func commonApprovalRewardsForBlock(config *params.ChainConfig, block *types.Block, keyblock *types.KeyBlock) []types.CommonApprovalReward {
+	if !core.CommonApprovalRequired(config, block) {
+		return nil
+	}
+	si := block.SignInfo()
+	if si == nil || len(si.CommonApprovalSignature) == 0 || len(si.CommonApprovalExceptions) == 0 {
+		return nil
+	}
+	nodes := core.OrderedCommonCommitteeForKeyBlock(config, keyblock)
+	if len(nodes) == 0 || si.CommonApprovalCommitteeHash != core.CommonApprovalCommitteeHashFromNodes(nodes) {
+		return nil
+	}
+
+	rewards := make([]types.CommonApprovalReward, 0, len(nodes))
+	for i, node := range nodes {
+		if node == nil || node.CoinBase == "" || len(si.CommonApprovalExceptions) <= i/8 {
 			continue
 		}
-		count := counts[node.CoinBase]
-		if count == 0 {
+		if (si.CommonApprovalExceptions[i/8] & (1 << uint(i%8))) == 0 {
 			continue
 		}
 		rewards = append(rewards, types.CommonApprovalReward{
 			CoinBase:       node.CoinBase,
-			SignedTxBlocks: count,
+			SignedTxBlocks: 1,
 		})
 	}
-	return rewards, nil
+	return rewards
 }
 
 func (keyS *keyService) verifyCommonApprovalRewardSummary(keyblock *types.KeyBlock, fromN, toN uint64) error {

--- a/reconfig/common_approval_rewards_test.go
+++ b/reconfig/common_approval_rewards_test.go
@@ -1,0 +1,160 @@
+package reconfig
+
+import (
+	"fmt"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/cypherium/cypher/common"
+	"github.com/cypherium/cypher/core"
+	"github.com/cypherium/cypher/core/types"
+	"github.com/cypherium/cypher/params"
+)
+
+func TestCommonApprovalRewardsUseKeyBlockActiveCommittee(t *testing.T) {
+	bootstrap := common.Cnode{
+		Address:  "bootstrap-address",
+		CoinBase: "0x0000000000000000000000000000000000000001",
+		Public:   "bootstrap-public",
+	}
+	dynamic := common.Cnode{
+		Address:  "dynamic-address",
+		CoinBase: "0x0000000000000000000000000000000000000002",
+		Public:   "dynamic-public",
+	}
+	config := &params.ChainConfig{
+		CommonApprovalEnabled: true,
+		CommonCommittee: params.GenesisCommittee{
+			core.CommonApprovalBootstrapIndex: bootstrap,
+		},
+	}
+	keyblock := types.NewKeyBlock(&types.KeyBlockHeader{
+		Difficulty: big.NewInt(1),
+		Number:     big.NewInt(1),
+	})
+	keyblock.SetActiveCommonCommittee([]types.CommonApprovalCommitteeMember{
+		{Address: bootstrap.Address, CoinBase: bootstrap.CoinBase, Public: bootstrap.Public},
+		{Address: dynamic.Address, CoinBase: dynamic.CoinBase, Public: dynamic.Public},
+	})
+	activeNodes := core.OrderedCommonCommitteeForKeyBlock(config, keyblock)
+	activeHash := core.CommonApprovalCommitteeHashFromNodes(activeNodes)
+	if activeHash == core.CommonApprovalCommitteeHash(config) {
+		t.Fatal("test requires the active committee hash to differ from the config fallback")
+	}
+
+	block := types.NewBlockWithHeader(&types.Header{
+		Difficulty: big.NewInt(1),
+		Number:     big.NewInt(1),
+		BlockType:  types.FastTx_Block,
+		KeyHash:    keyblock.Hash(),
+		SignInfo: types.SignInfo{
+			CommonApprovalSignature:     []byte{1},
+			CommonApprovalExceptions:    []byte{0x03},
+			CommonApprovalCommitteeHash: activeHash,
+		},
+	})
+
+	got := commonApprovalRewardsForBlock(config, block, keyblock)
+	want := []types.CommonApprovalReward{
+		{CoinBase: common.HexToAddress(bootstrap.CoinBase).Hex(), SignedTxBlocks: 1},
+		{CoinBase: common.HexToAddress(dynamic.CoinBase).Hex(), SignedTxBlocks: 1},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected rewards: have=%v want=%v", got, want)
+	}
+}
+
+func TestCommonApprovalRewardsHonorActiveCommitteeSignerMask(t *testing.T) {
+	bootstrap := common.Cnode{
+		Address:  "bootstrap-address",
+		CoinBase: "0x0000000000000000000000000000000000000011",
+		Public:   "bootstrap-public",
+	}
+	dynamic := common.Cnode{
+		Address:  "dynamic-address",
+		CoinBase: "0x0000000000000000000000000000000000000012",
+		Public:   "dynamic-public",
+	}
+	config := &params.ChainConfig{
+		CommonApprovalEnabled: true,
+		CommonCommittee: params.GenesisCommittee{
+			core.CommonApprovalBootstrapIndex: bootstrap,
+		},
+	}
+	keyblock := types.NewKeyBlock(&types.KeyBlockHeader{Difficulty: big.NewInt(1), Number: big.NewInt(1)})
+	keyblock.SetActiveCommonCommittee([]types.CommonApprovalCommitteeMember{
+		{Address: bootstrap.Address, CoinBase: bootstrap.CoinBase, Public: bootstrap.Public},
+		{Address: dynamic.Address, CoinBase: dynamic.CoinBase, Public: dynamic.Public},
+	})
+	activeHash := core.CommonApprovalCommitteeHashForKeyBlock(config, keyblock)
+	block := types.NewBlockWithHeader(&types.Header{
+		Difficulty: big.NewInt(1),
+		Number:     big.NewInt(1),
+		BlockType:  types.FastTx_Block,
+		SignInfo: types.SignInfo{
+			CommonApprovalSignature:     []byte{1},
+			CommonApprovalExceptions:    []byte{0x02},
+			CommonApprovalCommitteeHash: activeHash,
+		},
+	})
+
+	got := commonApprovalRewardsForBlock(config, block, keyblock)
+	want := []types.CommonApprovalReward{{CoinBase: common.HexToAddress(dynamic.CoinBase).Hex(), SignedTxBlocks: 1}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected rewards: have=%v want=%v", got, want)
+	}
+}
+
+func TestCommonApprovalRewardsSupportMaximumCommitteeSize(t *testing.T) {
+	const signerMask = byte(0x7f) // indexes 0 through 6: one leader and six committee members
+
+	committee := make([]types.CommonApprovalCommitteeMember, 0, core.CommonApprovalMaxCommitteeSize)
+	configCommittee := make(params.GenesisCommittee)
+	want := make([]types.CommonApprovalReward, 0, core.CommonApprovalMaxCommitteeSize)
+	for i := 0; i < core.CommonApprovalMaxCommitteeSize; i++ {
+		node := common.Cnode{
+			Address:  fmt.Sprintf("common-address-%d", i),
+			CoinBase: fmt.Sprintf("0x%040x", i+1),
+			Public:   fmt.Sprintf("common-public-%d", i),
+		}
+		if i == core.CommonApprovalBootstrapIndex {
+			configCommittee[i] = node
+		}
+		committee = append(committee, types.CommonApprovalCommitteeMember{
+			Address:  node.Address,
+			CoinBase: node.CoinBase,
+			Public:   node.Public,
+		})
+		want = append(want, types.CommonApprovalReward{
+			CoinBase:       common.HexToAddress(node.CoinBase).Hex(),
+			SignedTxBlocks: 1,
+		})
+	}
+	config := &params.ChainConfig{
+		CommonApprovalEnabled: true,
+		CommonCommittee:       configCommittee,
+	}
+	keyblock := types.NewKeyBlock(&types.KeyBlockHeader{Difficulty: big.NewInt(1), Number: big.NewInt(1)})
+	keyblock.SetActiveCommonCommittee(committee)
+	activeHash := core.CommonApprovalCommitteeHashForKeyBlock(config, keyblock)
+	if activeHash == core.CommonApprovalCommitteeHash(config) {
+		t.Fatal("test requires six dynamic members outside the config fallback")
+	}
+	block := types.NewBlockWithHeader(&types.Header{
+		Difficulty: big.NewInt(1),
+		Number:     big.NewInt(1),
+		BlockType:  types.FastTx_Block,
+		KeyHash:    keyblock.Hash(),
+		SignInfo: types.SignInfo{
+			CommonApprovalSignature:     []byte{1},
+			CommonApprovalExceptions:    []byte{signerMask},
+			CommonApprovalCommitteeHash: activeHash,
+		},
+	})
+
+	got := commonApprovalRewardsForBlock(config, block, keyblock)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected maximum-committee rewards: have=%v want=%v", got, want)
+	}
+}


### PR DESCRIPTION
### Motivation
- Ensure common approval rewards are resolved against the active committee snapshot recorded in the referenced `KeyBlock` instead of always using the config fallback to correctly attribute signer masks. 
- Make the reward-building logic clearer and more testable by factoring per-block resolution into a helper.

### Description
- Refactor `buildCommonApprovalRewardSummary` to aggregate per-block rewards produced by a new helper `commonApprovalRewardsForBlock` and preserve deterministic coinbase ordering. 
- Add `commonApprovalRewardsForBlock(config, block, keyblock)` which resolves signer mask indexes against the active common committee snapshot from the `KeyBlock` and returns per-block `CommonApprovalReward` entries. 
- Log a committee-hash mismatch and skip blocks when the recorded signer committee hash differs from the active committee derived from the keyblock. 
- Add unit tests in `common_approval_rewards_test.go` covering active-committee resolution, signer-mask honoring, and maximum committee size handling. 

### Testing
- Ran the new unit tests with `go test ./reconfig -run TestCommonApprovalRewards` which executed `TestCommonApprovalRewardsUseKeyBlockActiveCommittee`, `TestCommonApprovalRewardsHonorActiveCommitteeSignerMask`, and `TestCommonApprovalRewardsSupportMaximumCommitteeSize` and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2269e014d08330b17b1a14f85be5f7)