### PR TITLE
reconfig: wait for active committee votes before finalizing common approval and shorten vote timeout

### DIFF
--- a/reconfig/common_approval.go
+++ b/reconfig/common_approval.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	commonApprovalVoteTimeout     = 500 * time.Millisecond
+	commonApprovalVoteTimeout     = 100 * time.Millisecond
 	commonApprovalResponseTimeout = 2 * time.Second
 )
 
@@ -295,7 +295,7 @@ func (s *Service) handleCommonApprovalRequest(req *commonApprovalMsg) {
 
 	s.broadcastCommonApprovalVoteRequest(req)
 	commonApprovalRuntime.Lock()
-	resp := s.tryBuildCommonApprovalResponse(session)
+	resp := s.tryBuildCommonApprovalResponse(session, false)
 	commonApprovalRuntime.Unlock()
 	if resp != nil {
 		s.deliverCommonApprovalResponse(resp)
@@ -307,7 +307,7 @@ func (s *Service) handleCommonApprovalRequest(req *commonApprovalMsg) {
 		s.deliverCommonApprovalResponse(resp)
 	case <-time.After(commonApprovalVoteTimeout):
 		commonApprovalRuntime.Lock()
-		resp := s.tryBuildCommonApprovalResponse(session)
+		resp := s.tryBuildCommonApprovalResponse(session, true)
 		commonApprovalRuntime.Unlock()
 		if resp != nil {
 			s.deliverCommonApprovalResponse(resp)
@@ -383,7 +383,7 @@ func (s *Service) handleCommonApprovalVote(vote *commonApprovalMsg) {
 			session.votes = make(map[int][]byte)
 		}
 		session.votes[int(vote.SignerIndex)] = vote.Signature
-		resp = s.tryBuildCommonApprovalResponse(session)
+		resp = s.tryBuildCommonApprovalResponse(session, false)
 	}
 	commonApprovalRuntime.Unlock()
 	if session == nil || resp == nil {
@@ -482,13 +482,24 @@ func (s *Service) commonApprovalSessionThreshold(session *commonApprovalLeaderSe
 	return core.CommonApprovalThreshold(s.chainConfig, len(nodes))
 }
 
-func (s *Service) tryBuildCommonApprovalResponse(session *commonApprovalLeaderSession) *commonApprovalMsg {
+func commonApprovalVoteSetReady(voteCount, committeeSize, threshold int, allowPartial bool) bool {
+	if voteCount <= 0 || committeeSize <= 0 || threshold <= 0 || voteCount < threshold {
+		return false
+	}
+	return allowPartial || voteCount >= committeeSize
+}
+
+func (s *Service) tryBuildCommonApprovalResponse(session *commonApprovalLeaderSession, allowPartial bool) *commonApprovalMsg {
 	if session == nil {
 		return nil
 	}
 	nodes := s.orderedCommonCommitteeForBlock(session.block)
 	threshold := s.commonApprovalSessionThreshold(session)
-	if len(session.votes) < threshold {
+	// Once the safety threshold is reached, keep collecting until every active
+	// member has voted or the vote timeout expires. This prevents the bootstrap
+	// leader's threshold-one self vote from finalizing mask 0x01 before healthy
+	// dynamic committee members can vote and earn their signer reward.
+	if !commonApprovalVoteSetReady(len(session.votes), len(nodes), threshold, allowPartial) {
 		return nil
 	}
 	sig, mask, err := aggregateCommonApprovalSignatures(session.votes, len(nodes))

--- a/reconfig/common_approval_test.go
+++ b/reconfig/common_approval_test.go
@@ -1,0 +1,70 @@
+package reconfig
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCommonApprovalVoteSetWaitsForActiveMembers(t *testing.T) {
+	tests := []struct {
+		name          string
+		voteCount     int
+		committeeSize int
+		threshold     int
+		allowPartial  bool
+		want          bool
+	}{
+		{
+			name:          "bootstrap self vote waits for dynamic member",
+			voteCount:     1,
+			committeeSize: 2,
+			threshold:     1,
+			want:          false,
+		},
+		{
+			name:          "all active members respond",
+			voteCount:     2,
+			committeeSize: 2,
+			threshold:     1,
+			want:          true,
+		},
+		{
+			name:          "timeout keeps bootstrap fallback",
+			voteCount:     1,
+			committeeSize: 2,
+			threshold:     1,
+			allowPartial:  true,
+			want:          true,
+		},
+		{
+			name:          "timeout does not bypass normal threshold",
+			voteCount:     1,
+			committeeSize: 3,
+			threshold:     2,
+			allowPartial:  true,
+			want:          false,
+		},
+		{
+			name:          "single-member committee completes immediately",
+			voteCount:     1,
+			committeeSize: 1,
+			threshold:     1,
+			want:          true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := commonApprovalVoteSetReady(test.voteCount, test.committeeSize, test.threshold, test.allowPartial)
+			if got != test.want {
+				t.Fatalf("unexpected readiness: have=%t want=%t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCommonApprovalVoteTimeout(t *testing.T) {
+	if commonApprovalVoteTimeout != 100*time.Millisecond {
+		t.Fatalf("unexpected common approval vote timeout: have=%s want=%s", commonApprovalVoteTimeout, 100*time.Millisecond)
+	}
+}


### PR DESCRIPTION
### Motivation

- Prevent the bootstrap leader's single self-vote from finalizing a response before active dynamic committee members can vote and earn their signer reward. 
- Reduce the vote wait latency to make leader-driven common approval progress faster.

### Description

- Shorten `commonApprovalVoteTimeout` from `500 * time.Millisecond` to `100 * time.Millisecond`.
- Add `commonApprovalVoteSetReady` helper and extend `tryBuildCommonApprovalResponse` to accept an `allowPartial` flag so the leader can require all active members to vote unless the post-timeout path allows partial completion.
- Update places that call `tryBuildCommonApprovalResponse` to pass `allowPartial=false` for the initial fast path and `allowPartial=true` after the vote timeout elapses.
- Add unit tests in `common_approval_test.go` covering the vote readiness logic and the updated timeout constant.

### Testing

- Ran `go test` for the `reconfig` package; `TestCommonApprovalVoteSetWaitsForActiveMembers` and `TestCommonApprovalVoteTimeout` executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a229dae6dcc83309ff3361841415abd)