### PR TITLE
core, reconfig, internal/ethapi, eth: rename common tx approver fields

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -107,10 +107,10 @@ func buildCommonRewardIndex(rewards []*types.CommonTxReward) (map[common.Hash]*t
 		if reward.TxHash == (common.Hash{}) {
 			return nil, fmt.Errorf("invalid common tx reward: empty tx hash")
 		}
-		if reward.Reward == nil || reward.Burn == nil {
+		if reward.ApproverReward == nil || reward.Burn == nil {
 			return nil, fmt.Errorf("invalid common tx reward for %s: nil amount", reward.TxHash)
 		}
-		if reward.Reward.Sign() < 0 || reward.Burn.Sign() < 0 {
+		if reward.ApproverReward.Sign() < 0 || reward.Burn.Sign() < 0 {
 			return nil, fmt.Errorf("invalid common tx reward for %s: negative amount", reward.TxHash)
 		}
 		if _, exists := indexed[reward.TxHash]; exists {
@@ -121,30 +121,30 @@ func buildCommonRewardIndex(rewards []*types.CommonTxReward) (map[common.Hash]*t
 	return indexed, nil
 }
 
-func settleCommonRPCReward(statedb *state.StateDB, reward *types.CommonTxReward, expectedMiner common.Address, tx *types.Transaction, gasUsed uint64, baseFee *big.Int) error {
+func settleCommonRPCReward(statedb *state.StateDB, reward *types.CommonTxReward, expectedApprover common.Address, tx *types.Transaction, gasUsed uint64, baseFee *big.Int) error {
 	if reward == nil {
 		return fmt.Errorf("missing common tx reward for admitted tx %s", tx.Hash())
 	}
-	if expectedMiner == (common.Address{}) {
+	if expectedApprover == (common.Address{}) {
 		return fmt.Errorf("invalid common tx admission for %s: empty miner", tx.Hash())
 	}
 	if reward.TxHash != tx.Hash() {
 		return fmt.Errorf("invalid common tx reward hash: have %s want %s", reward.TxHash, tx.Hash())
 	}
-	if reward.Miner != expectedMiner {
-		return fmt.Errorf("invalid common tx reward miner for %s: have %s want %s", tx.Hash(), reward.Miner, expectedMiner)
+	if reward.Approver != expectedApprover {
+		return fmt.Errorf("invalid common tx reward approver for %s: have %s want %s", tx.Hash(), reward.Approver, expectedApprover)
 	}
 	actualFee := new(big.Int).Mul(new(big.Int).SetUint64(gasUsed), effectiveTxGasPrice(tx, baseFee))
 	expectedReward := new(big.Int).Div(actualFee, big.NewInt(5))
 	expectedBurn := new(big.Int).Sub(actualFee, expectedReward)
-	if reward.Reward.Cmp(expectedReward) != 0 {
-		return fmt.Errorf("invalid common tx reward for %s: have %s want %s", tx.Hash(), reward.Reward, expectedReward)
+	if reward.ApproverReward.Cmp(expectedReward) != 0 {
+		return fmt.Errorf("invalid common tx approver reward for %s: have %s want %s", tx.Hash(), reward.ApproverReward, expectedReward)
 	}
 	if reward.Burn.Cmp(expectedBurn) != 0 {
 		return fmt.Errorf("invalid common tx burn for %s: have %s want %s", tx.Hash(), reward.Burn, expectedBurn)
 	}
 	if expectedReward.Sign() > 0 {
-		statedb.AddBalance(expectedMiner, expectedReward)
+		statedb.AddBalance(expectedApprover, expectedReward)
 	}
 	// Burn is represented by intentionally not crediting the remaining fee to any account.
 	return nil

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -155,12 +155,12 @@ type CommonTxAdmission struct {
 }
 
 // CommonTxReward records the deterministic protocol-level split for one tx.
-// Reward is paid to Miner and Burn is intentionally not credited to any account.
+// ApproverReward is paid to Approver and Burn is intentionally not credited to any account.
 type CommonTxReward struct {
-	TxHash common.Hash
-	Miner  common.Address
-	Reward *big.Int
-	Burn   *big.Int
+	TxHash         common.Hash
+	Approver       common.Address
+	ApproverReward *big.Int
+	Burn           *big.Int
 }
 
 // Hash returns the block hash of the header, which is simply the keccak256 hash of its
@@ -308,8 +308,8 @@ func copyCommonTxRewards(in []*CommonTxReward) []*CommonTxReward {
 			continue
 		}
 		cpy := *reward
-		if reward.Reward != nil {
-			cpy.Reward = new(big.Int).Set(reward.Reward)
+		if reward.ApproverReward != nil {
+			cpy.ApproverReward = new(big.Int).Set(reward.ApproverReward)
 		}
 		if reward.Burn != nil {
 			cpy.Burn = new(big.Int).Set(reward.Burn)
@@ -355,8 +355,8 @@ func DeriveCommonTxRewardRoot(rewards []*CommonTxReward) common.Hash {
 		}
 		rewardAmount := new(big.Int)
 		burnAmount := new(big.Int)
-		if reward.Reward != nil {
-			rewardAmount.Set(reward.Reward)
+		if reward.ApproverReward != nil {
+			rewardAmount.Set(reward.ApproverReward)
 		}
 		if reward.Burn != nil {
 			burnAmount.Set(reward.Burn)
@@ -364,7 +364,7 @@ func DeriveCommonTxRewardRoot(rewards []*CommonTxReward) common.Hash {
 		leaves = append(leaves, blake3RLPHash([]interface{}{
 			[]byte(commonTxRewardDomain),
 			reward.TxHash,
-			reward.Miner,
+			reward.Approver,
 			rewardAmount,
 			burnAmount,
 		}))

--- a/eth/api.go
+++ b/eth/api.go
@@ -93,7 +93,7 @@ func addCommonRPCFields(fields map[string]interface{}, block *types.Block, hash 
 			continue
 		}
 
-		fields["commonRpcMiner"] = admission.Miner
+		fields["commonTxApprover"] = admission.Miner
 
 		if admission.ChainID != nil {
 			fields["commonTxAdmissionChainId"] = (*hexutil.Big)(admission.ChainID)
@@ -112,13 +112,13 @@ func addCommonRPCFields(fields map[string]interface{}, block *types.Block, hash 
 			continue
 		}
 
-		fields["commonRpcMiner"] = reward.Miner
+		fields["commonTxApprover"] = reward.Approver
 
-		if reward.Reward != nil {
-			fields["commonRpcReward"] = (*hexutil.Big)(reward.Reward)
+		if reward.ApproverReward != nil {
+			fields["commonTxApproverReward"] = (*hexutil.Big)(reward.ApproverReward)
 		}
 		if reward.Burn != nil {
-			fields["commonRpcBurn"] = (*hexutil.Big)(reward.Burn)
+			fields["commonTxBurn"] = (*hexutil.Big)(reward.Burn)
 		}
 
 		break

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1563,9 +1563,9 @@ type RPCTransaction struct {
 
 	CommonTxAdmissionRoot           *common.Hash    `json:"commonTxAdmissionRoot,omitempty"`
 	CommonTxRewardRoot              *common.Hash    `json:"commonTxRewardRoot,omitempty"`
-	CommonRpcMiner                  *common.Address `json:"commonRpcMiner,omitempty"`
-	CommonRpcReward                 *hexutil.Big    `json:"commonRpcReward,omitempty"`
-	CommonRpcBurn                   *hexutil.Big    `json:"commonRpcBurn,omitempty"`
+	CommonTxApprover                *common.Address `json:"commonTxApprover,omitempty"`
+	CommonTxApproverReward          *hexutil.Big    `json:"commonTxApproverReward,omitempty"`
+	CommonTxBurn                    *hexutil.Big    `json:"commonTxBurn,omitempty"`
 	CommonTxAdmissionChainID        *hexutil.Big    `json:"commonTxAdmissionChainId,omitempty"`
 	CommonTxAdmissionKeyBlockNumber *hexutil.Uint64 `json:"commonTxAdmissionKeyBlockNumber,omitempty"`
 	CommonTxAdmissionTxBlockNumber  *hexutil.Uint64 `json:"commonTxAdmissionTxBlockNumber,omitempty"`
@@ -1600,12 +1600,12 @@ func fillCommonRPCTransactionFields(result *RPCTransaction, block *types.Block, 
 			continue
 		}
 
-		miner := admission.Miner
+		approver := admission.Miner
 		keyBlockNumber := hexutil.Uint64(admission.KeyBlockNumber)
 		txBlockNumber := hexutil.Uint64(admission.TxBlockNumber)
 		timestamp := hexutil.Uint64(admission.Timestamp)
 
-		result.CommonRpcMiner = &miner
+		result.CommonTxApprover = &approver
 		if admission.ChainID != nil {
 			result.CommonTxAdmissionChainID = (*hexutil.Big)(new(big.Int).Set(admission.ChainID))
 		}
@@ -1622,14 +1622,14 @@ func fillCommonRPCTransactionFields(result *RPCTransaction, block *types.Block, 
 			continue
 		}
 
-		miner := reward.Miner
-		result.CommonRpcMiner = &miner
+		approver := reward.Approver
+		result.CommonTxApprover = &approver
 
-		if reward.Reward != nil {
-			result.CommonRpcReward = (*hexutil.Big)(new(big.Int).Set(reward.Reward))
+		if reward.ApproverReward != nil {
+			result.CommonTxApproverReward = (*hexutil.Big)(new(big.Int).Set(reward.ApproverReward))
 		}
 		if reward.Burn != nil {
-			result.CommonRpcBurn = (*hexutil.Big)(new(big.Int).Set(reward.Burn))
+			result.CommonTxBurn = (*hexutil.Big)(new(big.Int).Set(reward.Burn))
 		}
 
 		break
@@ -1650,7 +1650,7 @@ func addCommonRPCReceiptFields(fields map[string]interface{}, block *types.Block
 			continue
 		}
 
-		fields["commonRpcMiner"] = admission.Miner
+		fields["commonTxApprover"] = admission.Miner
 
 		if admission.ChainID != nil {
 			fields["commonTxAdmissionChainId"] = (*hexutil.Big)(new(big.Int).Set(admission.ChainID))
@@ -1669,13 +1669,13 @@ func addCommonRPCReceiptFields(fields map[string]interface{}, block *types.Block
 			continue
 		}
 
-		fields["commonRpcMiner"] = reward.Miner
+		fields["commonTxApprover"] = reward.Approver
 
-		if reward.Reward != nil {
-			fields["commonRpcReward"] = (*hexutil.Big)(new(big.Int).Set(reward.Reward))
+		if reward.ApproverReward != nil {
+			fields["commonTxApproverReward"] = (*hexutil.Big)(new(big.Int).Set(reward.ApproverReward))
 		}
 		if reward.Burn != nil {
-			fields["commonRpcBurn"] = (*hexutil.Big)(new(big.Int).Set(reward.Burn))
+			fields["commonTxBurn"] = (*hexutil.Big)(new(big.Int).Set(reward.Burn))
 		}
 
 		break

--- a/internal/ethapi/api_common_rpc.go
+++ b/internal/ethapi/api_common_rpc.go
@@ -82,9 +82,9 @@ func (s *PublicTransactionReceiptAPI) GetTransactionReceipt(ctx context.Context,
 	fields["status"] = hexutil.Uint(receipt.Status)
 
 	if reward := commonTxRewardForHash(block, hash); reward != nil {
-		fields["commonTxMiner"] = reward.Miner
-		if reward.Reward != nil {
-			fields["commonTxReward"] = (*hexutil.Big)(reward.Reward)
+		fields["commonTxApprover"] = reward.Approver
+		if reward.ApproverReward != nil {
+			fields["commonTxApproverReward"] = (*hexutil.Big)(reward.ApproverReward)
 		}
 		if reward.Burn != nil {
 			fields["commonTxBurn"] = (*hexutil.Big)(reward.Burn)

--- a/reconfig/txblock.go
+++ b/reconfig/txblock.go
@@ -123,7 +123,7 @@ func txEffectiveGasPrice(tx *types.Transaction, baseFee *big.Int) *big.Int {
 	return new(big.Int).Add(baseFee, tip)
 }
 
-func commonAdmissionMinerByTx(admissions []*types.CommonTxAdmission) map[common.Hash]common.Address {
+func commonAdmissionApproverByTx(admissions []*types.CommonTxAdmission) map[common.Hash]common.Address {
 	indexed := make(map[common.Hash]common.Address, len(admissions))
 	for _, admission := range admissions {
 		if admission == nil || admission.TxHash == (common.Hash{}) || admission.Miner == (common.Address{}) {
@@ -137,17 +137,17 @@ func commonAdmissionMinerByTx(admissions []*types.CommonTxAdmission) map[common.
 }
 
 func buildCommonTxRewards(txs types.Transactions, receipts types.Receipts, admissions []*types.CommonTxAdmission, baseFee *big.Int) []*types.CommonTxReward {
-	minerByTx := commonAdmissionMinerByTx(admissions)
-	if len(minerByTx) == 0 {
+	approverByTx := commonAdmissionApproverByTx(admissions)
+	if len(approverByTx) == 0 {
 		return nil
 	}
-	rewards := make([]*types.CommonTxReward, 0, len(minerByTx))
+	rewards := make([]*types.CommonTxReward, 0, len(approverByTx))
 	for i, tx := range txs {
 		if tx == nil || i >= len(receipts) || receipts[i] == nil {
 			continue
 		}
 		txHash := tx.Hash()
-		miner, ok := minerByTx[txHash]
+		approver, ok := approverByTx[txHash]
 		if !ok {
 			continue
 		}
@@ -155,10 +155,10 @@ func buildCommonTxRewards(txs types.Transactions, receipts types.Receipts, admis
 		reward := new(big.Int).Div(actualFee, big.NewInt(5))
 		burn := new(big.Int).Sub(actualFee, reward)
 		rewards = append(rewards, &types.CommonTxReward{
-			TxHash: txHash,
-			Miner:  miner,
-			Reward: reward,
-			Burn:   burn,
+			TxHash:         txHash,
+			Approver:       approver,
+			ApproverReward: reward,
+			Burn:           burn,
 		})
 	}
 	return rewards
@@ -169,10 +169,10 @@ func applyCommonTxRewards(st *state.StateDB, rewards []*types.CommonTxReward) {
 		return
 	}
 	for _, reward := range rewards {
-		if reward == nil || reward.Miner == (common.Address{}) || reward.Reward == nil || reward.Reward.Sign() <= 0 {
+		if reward == nil || reward.Approver == (common.Address{}) || reward.ApproverReward == nil || reward.ApproverReward.Sign() <= 0 {
 			continue
 		}
-		st.AddBalance(reward.Miner, reward.Reward)
+		st.AddBalance(reward.Approver, reward.ApproverReward)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- The common node is a transaction approver (accepting and signing admissions) rather than a miner, so public RPC output and the `CommonTxReward` struct should use Approver terminology instead of Miner terminology.
- This change standardizes naming for clarity only, without altering any runtime logic or adding new RPC methods.
- `CommonTxAdmission.Miner` is intentionally left unchanged because it is part of the existing admission signing payload and verification flow.

### Description

- Renamed `CommonTxReward` fields in `core/types/block.go` from `Miner`/`Reward` to `Approver`/`ApproverReward` and updated related copy/merkle logic to use the new fields.
- Updated reward validation and settlement in `core/state_processor.go` to reference `Approver`/`ApproverReward` (no behavior changes to calculations or balance applications other than using the renamed fields internally).
- Updated reward construction and application in `reconfig/txblock.go`, including renaming the helper `commonAdmissionMinerByTx` -> `commonAdmissionApproverByTx` and local variables (`miner*` -> `approver*`).
- Renamed public RPC transaction/receipt fields in `internal/ethapi/api.go` (RPC struct and `fillCommonRPCTransactionFields` / `addCommonRPCReceiptFields`) from `commonRpcMiner`/`commonRpcReward`/`commonRpcBurn` to `commonTxApprover`/`commonTxApproverReward`/`commonTxBurn` and updated where those values are populated.
- Applied the same RPC key renames in the alternate receipt path files `eth/api.go` and `internal/ethapi/api_common_rpc.go` so no legacy RPC keys or old struct field references remain.
- No new files were added, no RPC method signatures were introduced, and no protocol logic was changed beyond renaming identifiers and JSON output keys.

### Testing

- Ran formatting with `gofmt -w core/types/block.go core/state_processor.go reconfig/txblock.go internal/ethapi/api.go internal/ethapi/api_common_rpc.go eth/api.go` which completed successfully.
- Searched for legacy identifiers with grep/ripgrep and confirmed no remaining occurrences of `commonRpcMiner`, `commonRpcReward`, `commonRpcBurn`, `reward.Miner`, or `reward.Reward` in the modified directories.
- Performed `git diff --check` and local diff validation (no whitespace or reverse-apply issues found).
- Attempted `go test ./core/types ./core ./reconfig ./internal/ethapi` but automated test execution could not complete in this environment due to module/GOPATH and vendoring issues (no repository root `go.mod` present and dependency/vendor inconsistencies / proxy access errors), and `make cypher` could not be run for the same reasons.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a260e3dbe6483308d9db8e12a5af1bb)