### PR TITLE
eth, core: preserve common tx data in block bodies

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -372,10 +372,10 @@ func DeriveCommonTxRewardRoot(rewards []*CommonTxReward) common.Hash {
 	return blake3MerkleRoot(leaves)
 }
 
-// EmptyBody returns true if there is no additional 'body' to complete the header
-// that is: no transactions and no uncles.
+// EmptyBody returns true if there is no additional body content to complete the header.
 func (h *Header) EmptyBody() bool {
-	return h.TxHash == EmptyRootHash && h.UncleHash == EmptyUncleHash
+	return h.TxHash == EmptyRootHash && h.UncleHash == EmptyUncleHash &&
+		h.CommonTxAdmissionRoot == (common.Hash{}) && h.CommonTxRewardRoot == (common.Hash{})
 }
 
 // EmptyReceipts returns true if there are no receipts for this header/block.

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1198,7 +1198,7 @@ func (d *Downloader) fetchBodies(from uint64) error {
 	var (
 		deliver = func(packet dataPack) (int, error) {
 			pack := packet.(*bodyPack)
-			return d.queue.DeliverBodies(pack.peerID, pack.transactions, pack.uncles)
+			return d.queue.DeliverBodies(pack.peerID, pack.transactions, pack.uncles, pack.commonTxAdmissions, pack.commonTxRewards)
 		}
 		expire   = func() map[string]int { return d.queue.ExpireBodies(d.requestTTL()) }
 		fetch    = func(p *peerConnection, req *fetchRequest) error { return p.FetchBodies(req) }
@@ -1638,6 +1638,7 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 	blocks := make([]*types.Block, len(results))
 	for i, result := range results {
 		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles)
+		blocks[i].SetCommonTxData(result.CommonTxAdmissions, result.CommonTxRewards)
 	}
 	if index, err := d.blockchain.InsertChain(blocks); err != nil {
 		if index < len(results) {
@@ -1799,6 +1800,7 @@ func (d *Downloader) commitFastSyncData(results []*fetchResult, stateSync *state
 	receipts := make([]types.Receipts, len(results))
 	for i, result := range results {
 		blocks[i] = types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles)
+		blocks[i].SetCommonTxData(result.CommonTxAdmissions, result.CommonTxRewards)
 		receipts[i] = result.Receipts
 	}
 	if index, err := d.blockchain.InsertReceiptChain(blocks, receipts, d.ancientLimit); err != nil {
@@ -1810,6 +1812,7 @@ func (d *Downloader) commitFastSyncData(results []*fetchResult, stateSync *state
 
 func (d *Downloader) commitPivotBlock(result *fetchResult) error {
 	block := types.NewBlockWithHeader(result.Header).WithBody(result.Transactions, result.Uncles)
+	block.SetCommonTxData(result.CommonTxAdmissions, result.CommonTxRewards)
 	log.Debug("Committing fast sync pivot as new head", "number", block.Number(), "hash", block.Hash())
 
 	// Commit the pivot block as the new head, will require full sync from here on
@@ -1839,8 +1842,8 @@ func (d *Downloader) DeliverHeaders(id string, headers []*types.Header) (err err
 }
 
 // DeliverBodies injects a new batch of block bodies received from a remote node.
-func (d *Downloader) DeliverBodies(id string, transactions [][]*types.Transaction, uncles [][]*types.Header) (err error) {
-	return d.deliver(id, d.bodyCh, &bodyPack{id, transactions, uncles}, bodyInMeter, bodyDropMeter)
+func (d *Downloader) DeliverBodies(id string, transactions [][]*types.Transaction, uncles [][]*types.Header, commonTxAdmissions [][]*types.CommonTxAdmission, commonTxRewards [][]*types.CommonTxReward) (err error) {
+	return d.deliver(id, d.bodyCh, &bodyPack{id, transactions, uncles, commonTxAdmissions, commonTxRewards}, bodyInMeter, bodyDropMeter)
 }
 
 // DeliverReceipts injects a new batch of receipts received from a remote node.

--- a/eth/downloader/fakepeer.go
+++ b/eth/downloader/fakepeer.go
@@ -123,16 +123,20 @@ func (p *FakePeer) RequestHeadersByNumber(number uint64, amount int, skip int, r
 // corresponding to the specified block hashes.
 func (p *FakePeer) RequestBodies(hashes []common.Hash) error {
 	var (
-		txs    [][]*types.Transaction
-		uncles [][]*types.Header
+		txs                [][]*types.Transaction
+		uncles             [][]*types.Header
+		commonTxAdmissions [][]*types.CommonTxAdmission
+		commonTxRewards    [][]*types.CommonTxReward
 	)
 	for _, hash := range hashes {
 		block := rawdb.ReadBlock(p.db, hash, *p.hc.GetBlockNumber(hash))
 
 		txs = append(txs, block.Transactions())
 		uncles = append(uncles, block.Uncles())
+		commonTxAdmissions = append(commonTxAdmissions, block.CommonTxAdmissions())
+		commonTxRewards = append(commonTxRewards, block.CommonTxRewards())
 	}
-	p.dl.DeliverBodies(p.id, txs, uncles)
+	p.dl.DeliverBodies(p.id, txs, uncles, commonTxAdmissions, commonTxRewards)
 	return nil
 }
 

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -63,10 +63,12 @@ type fetchRequest struct {
 type fetchResult struct {
 	pending int32 // Flag telling what deliveries are outstanding
 
-	Header       *types.Header
-	Uncles       []*types.Header
-	Transactions types.Transactions
-	Receipts     types.Receipts
+	Header             *types.Header
+	Uncles             []*types.Header
+	Transactions       types.Transactions
+	CommonTxAdmissions []*types.CommonTxAdmission
+	CommonTxRewards    []*types.CommonTxReward
+	Receipts           types.Receipts
 }
 
 func newFetchResult(header *types.Header, fastSync bool) *fetchResult {
@@ -768,7 +770,7 @@ func (q *queue) DeliverHeaders(id string, headers []*types.Header, headerProcCh 
 // DeliverBodies injects a block body retrieval response into the results queue.
 // The method returns the number of blocks bodies accepted from the delivery and
 // also wakes any threads waiting for data delivery.
-func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction, uncleLists [][]*types.Header) (int, error) {
+func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction, uncleLists [][]*types.Header, commonTxAdmissionLists [][]*types.CommonTxAdmission, commonTxRewardLists [][]*types.CommonTxReward) (int, error) {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 	validate := func(index int, header *types.Header) error {
@@ -778,12 +780,20 @@ func (q *queue) DeliverBodies(id string, txLists [][]*types.Transaction, uncleLi
 		if types.CalcUncleHash(uncleLists[index]) != header.UncleHash {
 			return errInvalidBody
 		}
+		if types.DeriveCommonTxAdmissionRoot(commonTxAdmissionLists[index]) != header.CommonTxAdmissionRoot {
+			return errInvalidBody
+		}
+		if types.DeriveCommonTxRewardRoot(commonTxRewardLists[index]) != header.CommonTxRewardRoot {
+			return errInvalidBody
+		}
 		return nil
 	}
 
 	reconstruct := func(index int, result *fetchResult) {
 		result.Transactions = txLists[index]
 		result.Uncles = uncleLists[index]
+		result.CommonTxAdmissions = commonTxAdmissionLists[index]
+		result.CommonTxRewards = commonTxRewardLists[index]
 		result.SetBodyDone()
 	}
 	return q.deliver(id, q.blockTaskPool, q.blockTaskQueue, q.blockPendPool,

--- a/eth/downloader/types.go
+++ b/eth/downloader/types.go
@@ -44,19 +44,30 @@ func (p *headerPack) Stats() string  { return fmt.Sprintf("%d", len(p.headers)) 
 
 // bodyPack is a batch of block bodies returned by a peer.
 type bodyPack struct {
-	peerID       string
-	transactions [][]*types.Transaction
-	uncles       [][]*types.Header
+	peerID             string
+	transactions       [][]*types.Transaction
+	uncles             [][]*types.Header
+	commonTxAdmissions [][]*types.CommonTxAdmission
+	commonTxRewards    [][]*types.CommonTxReward
 }
 
 func (p *bodyPack) PeerId() string { return p.peerID }
 func (p *bodyPack) Items() int {
-	if len(p.transactions) <= len(p.uncles) {
-		return len(p.transactions)
+	items := len(p.transactions)
+	if len(p.uncles) < items {
+		items = len(p.uncles)
 	}
-	return len(p.uncles)
+	if len(p.commonTxAdmissions) < items {
+		items = len(p.commonTxAdmissions)
+	}
+	if len(p.commonTxRewards) < items {
+		items = len(p.commonTxRewards)
+	}
+	return items
 }
-func (p *bodyPack) Stats() string { return fmt.Sprintf("%d:%d", len(p.transactions), len(p.uncles)) }
+func (p *bodyPack) Stats() string {
+	return fmt.Sprintf("%d:%d:%d:%d", len(p.transactions), len(p.uncles), len(p.commonTxAdmissions), len(p.commonTxRewards))
+}
 
 // receiptPack is a batch of receipts returned by a peer.
 type receiptPack struct {

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -118,13 +118,14 @@ type headerFilterTask struct {
 	time    time.Time       // Arrival time of the headers
 }
 
-// bodyFilterTask represents a batch of block bodies (transactions and uncles)
-// needing fetcher filtering.
+// bodyFilterTask represents a batch of block bodies needing fetcher filtering.
 type bodyFilterTask struct {
-	peer         string                 // The source peer of block bodies
-	transactions [][]*types.Transaction // Collection of transactions per block bodies
-	uncles       [][]*types.Header      // Collection of uncles per block bodies
-	time         time.Time              // Arrival time of the blocks' contents
+	peer               string                       // The source peer of block bodies
+	transactions       [][]*types.Transaction       // Collection of transactions per block body
+	uncles             [][]*types.Header            // Collection of uncles per block body
+	commonTxAdmissions [][]*types.CommonTxAdmission // Collection of common transaction admissions per block body
+	commonTxRewards    [][]*types.CommonTxReward    // Collection of common transaction rewards per block body
+	time               time.Time                    // Arrival time of the blocks' contents
 }
 
 // blockOrHeaderInject represents a schedules import operation.
@@ -301,8 +302,8 @@ func (f *BlockFetcher) FilterHeaders(peer string, headers []*types.Header, time 
 
 // FilterBodies extracts all the block bodies that were explicitly requested by
 // the fetcher, returning those that should be handled differently.
-func (f *BlockFetcher) FilterBodies(peer string, transactions [][]*types.Transaction, uncles [][]*types.Header, time time.Time) ([][]*types.Transaction, [][]*types.Header) {
-	log.Trace("Filtering bodies", "peer", peer, "txs", len(transactions), "uncles", len(uncles))
+func (f *BlockFetcher) FilterBodies(peer string, transactions [][]*types.Transaction, uncles [][]*types.Header, commonTxAdmissions [][]*types.CommonTxAdmission, commonTxRewards [][]*types.CommonTxReward, time time.Time) ([][]*types.Transaction, [][]*types.Header, [][]*types.CommonTxAdmission, [][]*types.CommonTxReward) {
+	log.Trace("Filtering bodies", "peer", peer, "txs", len(transactions), "uncles", len(uncles), "commonTxAdmissions", len(commonTxAdmissions), "commonTxRewards", len(commonTxRewards))
 
 	// Send the filter channel to the fetcher
 	filter := make(chan *bodyFilterTask)
@@ -310,20 +311,20 @@ func (f *BlockFetcher) FilterBodies(peer string, transactions [][]*types.Transac
 	select {
 	case f.bodyFilter <- filter:
 	case <-f.quit:
-		return nil, nil
+		return nil, nil, nil, nil
 	}
 	// Request the filtering of the body list
 	select {
-	case filter <- &bodyFilterTask{peer: peer, transactions: transactions, uncles: uncles, time: time}:
+	case filter <- &bodyFilterTask{peer: peer, transactions: transactions, uncles: uncles, commonTxAdmissions: commonTxAdmissions, commonTxRewards: commonTxRewards, time: time}:
 	case <-f.quit:
-		return nil, nil
+		return nil, nil, nil, nil
 	}
 	// Retrieve the bodies remaining after filtering
 	select {
 	case task := <-filter:
-		return task.transactions, task.uncles
+		return task.transactions, task.uncles, task.commonTxAdmissions, task.commonTxRewards
 	case <-f.quit:
-		return nil, nil
+		return nil, nil, nil, nil
 	}
 }
 
@@ -602,12 +603,14 @@ func (f *BlockFetcher) loop() {
 			blocks := []*types.Block{}
 			// abort early if there's nothing explicitly requested
 			if len(f.completing) > 0 {
-				for i := 0; i < len(task.transactions) && i < len(task.uncles); i++ {
+				for i := 0; i < len(task.transactions) && i < len(task.uncles) && i < len(task.commonTxAdmissions) && i < len(task.commonTxRewards); i++ {
 					// Match up a body to any possible completion request
 					var (
-						matched   = false
-						uncleHash common.Hash // calculated lazily and reused
-						txnHash   common.Hash // calculated lazily and reused
+						matched               = false
+						uncleHash             common.Hash // calculated lazily and reused
+						txnHash               common.Hash // calculated lazily and reused
+						commonTxAdmissionRoot common.Hash // calculated lazily and reused
+						commonTxRewardRoot    common.Hash // calculated lazily and reused
 					)
 					for hash, announce := range f.completing {
 						if f.queued[hash] != nil || announce.origin != task.peer {
@@ -625,10 +628,23 @@ func (f *BlockFetcher) loop() {
 						if txnHash != announce.header.TxHash {
 							continue
 						}
+						if commonTxAdmissionRoot == (common.Hash{}) {
+							commonTxAdmissionRoot = types.DeriveCommonTxAdmissionRoot(task.commonTxAdmissions[i])
+						}
+						if commonTxAdmissionRoot != announce.header.CommonTxAdmissionRoot {
+							continue
+						}
+						if commonTxRewardRoot == (common.Hash{}) {
+							commonTxRewardRoot = types.DeriveCommonTxRewardRoot(task.commonTxRewards[i])
+						}
+						if commonTxRewardRoot != announce.header.CommonTxRewardRoot {
+							continue
+						}
 						// Mark the body matched, reassemble if still unknown
 						matched = true
 						if f.getBlock(hash) == nil {
 							block := types.NewBlockWithHeader(announce.header).WithBody(task.transactions[i], task.uncles[i])
+							block.SetCommonTxData(task.commonTxAdmissions[i], task.commonTxRewards[i])
 							block.ReceivedAt = task.time
 							blocks = append(blocks, block)
 						} else {
@@ -639,6 +655,8 @@ func (f *BlockFetcher) loop() {
 					if matched {
 						task.transactions = append(task.transactions[:i], task.transactions[i+1:]...)
 						task.uncles = append(task.uncles[:i], task.uncles[i+1:]...)
+						task.commonTxAdmissions = append(task.commonTxAdmissions[:i], task.commonTxAdmissions[i+1:]...)
+						task.commonTxRewards = append(task.commonTxRewards[:i], task.commonTxRewards[i+1:]...)
 						i--
 						continue
 					}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -575,18 +575,22 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		// Deliver them all to the downloader for queuing
 		transactions := make([][]*types.Transaction, len(request))
 		uncles := make([][]*types.Header, len(request))
+		commonTxAdmissions := make([][]*types.CommonTxAdmission, len(request))
+		commonTxRewards := make([][]*types.CommonTxReward, len(request))
 
 		for i, body := range request {
 			transactions[i] = body.Transactions
 			uncles[i] = body.Uncles
+			commonTxAdmissions[i] = body.CommonTxAdmissions
+			commonTxRewards[i] = body.CommonTxRewards
 		}
 		// Filter out any explicitly requested bodies, deliver the rest to the downloader
-		filter := len(transactions) > 0 || len(uncles) > 0
+		filter := len(transactions) > 0 || len(uncles) > 0 || len(commonTxAdmissions) > 0 || len(commonTxRewards) > 0
 		if filter {
-			transactions, uncles = pm.blockFetcher.FilterBodies(p.id, transactions, uncles, time.Now())
+			transactions, uncles, commonTxAdmissions, commonTxRewards = pm.blockFetcher.FilterBodies(p.id, transactions, uncles, commonTxAdmissions, commonTxRewards, time.Now())
 		}
-		if len(transactions) > 0 || len(uncles) > 0 || !filter {
-			err := pm.downloader.DeliverBodies(p.id, transactions, uncles)
+		if len(transactions) > 0 || len(uncles) > 0 || len(commonTxAdmissions) > 0 || len(commonTxRewards) > 0 || !filter {
+			err := pm.downloader.DeliverBodies(p.id, transactions, uncles, commonTxAdmissions, commonTxRewards)
 			if err != nil {
 				log.Debug("Failed to deliver bodies", "err", err)
 			}

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -177,8 +177,10 @@ func (request *newBlockData) sanityCheck() error {
 
 // blockBody represents the data content of a single block.
 type blockBody struct {
-	Transactions []*types.Transaction // Transactions contained within a block
-	Uncles       []*types.Header      // Uncles contained within a block
+	Transactions       []*types.Transaction       // Transactions contained within a block
+	Uncles             []*types.Header            // Uncles contained within a block
+	CommonTxAdmissions []*types.CommonTxAdmission // Common transaction admissions contained within a block
+	CommonTxRewards    []*types.CommonTxReward    // Common transaction rewards contained within a block
 }
 
 type blockBodiesData []*blockBody


### PR DESCRIPTION
### Motivation

- P2P RLP decoding failed with `rlp: input list has too many elements for eth.blockBody` after `CommonTxAdmissions`/`CommonTxRewards` were added to `core/types.Body`, so the wire type must be extended and the four body components preserved end-to-end.
- The change must not touch consensus or reward logic, only the P2P/protocol, fetcher, and downloader paths that previously dropped the new fields.

### Description

- Extended the ETH wire type `blockBody` to include `CommonTxAdmissions` and `CommonTxRewards` so `BlockBodiesMsg` decodes the full 4-part body (`Transactions`, `Uncles`, `CommonTxAdmissions`, `CommonTxRewards`) (`eth/protocol.go`).
- Propagated the new slices through handler -> fetcher -> downloader: updated `BlockBodiesMsg` handling (`eth/handler.go`), `FilterBodies` signature and logic (`eth/fetcher/block_fetcher.go`), downloader `bodyPack` and `DeliverBodies` APIs (`eth/downloader/types.go`, `eth/downloader/downloader.go`), and queue delivery/reconstruction (`eth/downloader/queue.go`) to validate and keep the common-tx roots and attach data to reconstructed blocks.
- Ensured fetched/announced bodies reconstructed by the fetcher preserve common-tx data and validate against header roots before acceptance, and set the data on blocks during import (`eth/fetcher/block_fetcher.go`, `eth/downloader/downloader.go`).
- Treated headers that carry common-tx roots as non-empty bodies so they are scheduled for retrieval by updating `Header.EmptyBody` logic (`core/types/block.go`) and updated the downloader fake-peer to deliver the new fields for tests (`eth/downloader/fakepeer.go`).

### Testing

- Ran formatting with `gofmt` on modified files and static validations (grep) to ensure all body delivery paths reference `type blockBody`, `DeliverBodies`, `FilterBodies`, `CommonTxAdmissions`, and `CommonTxRewards` (successful).
- Ran `git diff --check` and repository status checks (successful) and created the change as a single focused commit.
- Attempted package tests with legacy GOPATH mode (`GO111MODULE=off GOPATH=... go test ...`) but full unit tests could not run due to missing vendored dependencies in this environment (examples: `golang.org/x/sys/cpu`, `github.com/VictoriaMetrics/fastcache`, `github.com/shirou/gopsutil/cpu`), so runtime test execution was blocked; code-path level validations (grep/diff/format) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a261ac0dca08330aba6dbe22e2a5d85)