### PR TITLE
Support large KCP packets and increase tx/block proposal limits

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -142,8 +142,8 @@ const (
 	// With 100k+ wallets, building a full candidate account list for every
 	// proposal is too expensive. Limit the number of account candidates scanned
 	// per proposal and let subsequent proposals drain the rest.
-	fastPendingCandidateScanLimit = 8192
-	slowPendingCandidateScanLimit = 8192
+	fastPendingCandidateScanLimit = 131072
+	slowPendingCandidateScanLimit = 65536
 )
 
 type pendingReadyIndex struct {

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -45,7 +45,7 @@ var ProtocolVersions = []uint{eth64, eth63}
 // protocolLengths are the number of implemented message corresponding to different protocol versions.
 var protocolLengths = map[uint]uint64{eth64: 17, eth63: 17}
 
-const protocolMaxMsgSize = 10 * 1024 * 1024 // Maximum cap on the size of a protocol message
+const protocolMaxMsgSize = 257 * 1024 * 1024 // Maximum cap on the size of a protocol message
 
 // eth protocol message codes
 const (

--- a/reconfig/txblock.go
+++ b/reconfig/txblock.go
@@ -379,13 +379,13 @@ const (
 	slowPerAccountTierMedium = 128
 	fastPerAccountTierLarge  = 512
 	slowPerAccountTierLarge  = 512
-	fastBlockMaxTxCount      = uint64(8000)
-	slowBlockMaxTxCount      = uint64(24000)
+	fastBlockMaxTxCount      = uint64(100000)
+	slowBlockMaxTxCount      = uint64(50000)
 	fastBlockGasTargetPct    = uint64(95)
 	slowBlockGasTargetPct    = uint64(99)
 
-	fastTxBlockProposalMaxBytes = 8 * 1024 * 1024
-	slowTxBlockProposalMaxBytes = 16 * 1024 * 1024
+	fastTxBlockProposalMaxBytes = 128 * 1024 * 1024
+	slowTxBlockProposalMaxBytes = 256 * 1024 * 1024
 
 	deployBlockGasTargetPct = uint64(10)
 	heavyBlockGasTargetPct  = uint64(5)
@@ -418,7 +418,7 @@ const (
 	deployBlockMaxTxCount = uint64(4)
 	heavyBlockMaxTxCount  = uint64(8)
 	dataBlockMaxTxCount   = uint64(8)
-	dexBlockMaxTxCount    = uint64(10000)
+	dexBlockMaxTxCount    = slowBlockMaxTxCount
 
 	deployDrainMaxTxCount = uint64(16)
 	heavyDrainMaxTxCount  = uint64(32)

--- a/rnet/network/kcp.go
+++ b/rnet/network/kcp.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -18,8 +19,11 @@ import (
 
 // ----------------------------------------------------------------------------------------------------
 const (
-	def_headerSize    = 6
-	def_MaxPacketSize = 10 * 1024 * 1024
+	def_headerSize           = 6
+	def_extendedSize         = 4
+	def_extendedPacketMarker = uint32(0)
+	def_legacyMaxPacketSize  = uint32(0xFFFFFF)
+	def_MaxPacketSize        = 257 * 1024 * 1024
 )
 
 var (
@@ -143,12 +147,26 @@ func (c *KCPConn) receiveRaw() ([]byte, error) {
 		return nil, err
 	}
 
-	// Check the message header
-	total := readInt24(headBuf)
-	if headBuf[3] != def_headerMagic[0] || headBuf[4] != def_headerMagic[1] || headBuf[5] != def_headerMagic[2] {
+	// Check the message header. Large packets use the reserved 24-bit length
+	// value followed by a 32-bit length, while ordinary packets retain the
+	// original wire format.
+	total, extended, validHeader := decodePacketHeader(headBuf)
+	if !validHeader {
 		err := fmt.Errorf("Buffer head not match! ")
 		log.Info("receiveRaw", "header check fail", "error", err)
 		return nil, err
+	}
+	headerSize := uint64(def_headerSize)
+	if extended {
+		extendedBuf := make([]byte, def_extendedSize)
+		c.setReadDeadline(ReadTimeout)
+		_, err := io.ReadFull(c.conn, extendedBuf)
+		c.setReadDeadline(0)
+		if err != nil {
+			return nil, err
+		}
+		total = binary.BigEndian.Uint32(extendedBuf)
+		headerSize += def_extendedSize
 	}
 
 	if total > def_MaxPacketSize {
@@ -166,7 +184,7 @@ func (c *KCPConn) receiveRaw() ([]byte, error) {
 		c.setReadDeadline(0)
 		// Quit if there is an error.
 		if err != nil {
-			c.updateRx(def_headerSize + uint64(read))
+			c.updateRx(headerSize + uint64(read))
 			return nil, handleError(err)
 		}
 		// Append the read bytes into the buffer.
@@ -177,9 +195,8 @@ func (c *KCPConn) receiveRaw() ([]byte, error) {
 		b = b[n:]
 	}
 
-	// register how many bytes we read. (4 is for the frame size
-	// that we read up above).
-	c.updateRx(def_headerSize + uint64(read))
+	// Register the payload and framing bytes read from the connection.
+	c.updateRx(headerSize + uint64(read))
 	return buffer.Bytes(), nil
 }
 
@@ -201,12 +218,15 @@ func (c *KCPConn) Send(msg Message) (uint64, error) {
 // whole message b in slices of size maxChunkSize.
 // In case of an error it aborts.
 func (c *KCPConn) sendRaw(b []byte) (uint64, error) {
-	// First write the size
+	if uint64(len(b)) > uint64(def_MaxPacketSize) {
+		return 0, fmt.Errorf("packet too large: %d>%d", len(b), def_MaxPacketSize)
+	}
+
+	// Keep the original 24-bit header for ordinary messages. Transaction block
+	// proposals above that limit use an extended 32-bit packet length.
 	packetSize := uint32(len(b))
 
-	headBuf := make([]byte, def_headerSize)
-	putInt24(packetSize, headBuf)
-	copy(headBuf[3:], def_headerMagic)
+	headBuf := encodePacketHeader(packetSize)
 
 	if _, err := c.conn.Write(headBuf); err != nil {
 		return 0, err
@@ -219,14 +239,14 @@ func (c *KCPConn) sendRaw(b []byte) (uint64, error) {
 	for sent < packetSize {
 		n, err := c.conn.Write(b[sent:])
 		if err != nil {
-			sentLen := def_headerSize + uint64(sent)
+			sentLen := uint64(len(headBuf)) + uint64(sent)
 			c.updateTx(sentLen)
 			return sentLen, handleError(err)
 		}
 		sent += uint32(n)
 	}
-	// update stats on the connection. Plus 4 for the uint32 for the frame size.
-	sentLen := def_headerSize + uint64(sent)
+	// Update stats on the connection, including the legacy or extended header.
+	sentLen := uint64(len(headBuf)) + uint64(sent)
 	c.updateTx(sentLen)
 	return sentLen, nil
 }
@@ -513,6 +533,30 @@ func (t *KCPHost) Connect(si *ServerIdentity) (Conn, error) {
 		return nil, errors.New("This address is not correctly formatted: " + si.Address.String())
 	}
 	return nil, fmt.Errorf("KCPHost %s can't handle this type of connection: %s", si.Address, si.Address.ConnType())
+}
+
+func encodePacketHeader(size uint32) []byte {
+	header := make([]byte, def_headerSize, def_headerSize+def_extendedSize)
+	encodedSize := size
+	if size > def_legacyMaxPacketSize {
+		encodedSize = def_extendedPacketMarker
+	}
+	putInt24(encodedSize, header)
+	copy(header[3:], def_headerMagic)
+	if encodedSize == def_extendedPacketMarker {
+		extended := make([]byte, def_extendedSize)
+		binary.BigEndian.PutUint32(extended, size)
+		header = append(header, extended...)
+	}
+	return header
+}
+
+func decodePacketHeader(header []byte) (size uint32, extended bool, valid bool) {
+	if len(header) != def_headerSize || !bytes.Equal(header[3:], def_headerMagic) {
+		return 0, false, false
+	}
+	size = readInt24(header)
+	return size, size == def_extendedPacketMarker, true
 }
 
 func readInt24(b []byte) uint32 {

--- a/rnet/network/kcp_test.go
+++ b/rnet/network/kcp_test.go
@@ -1,0 +1,54 @@
+package network
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestPacketHeaderSupportsLargeTxBlockProposal(t *testing.T) {
+	want := uint32(256 * 1024 * 1024)
+	header := encodePacketHeader(want)
+	if len(header) != def_headerSize+def_extendedSize {
+		t.Fatalf("extended header size mismatch: got %d, want %d", len(header), def_headerSize+def_extendedSize)
+	}
+
+	marker, extended, ok := decodePacketHeader(header[:def_headerSize])
+	if !ok || !extended {
+		t.Fatal("large packet header was not recognized as extended")
+	}
+	if marker != def_extendedPacketMarker {
+		t.Fatalf("packet marker mismatch: got %d, want %d", marker, def_extendedPacketMarker)
+	}
+	if got := binary.BigEndian.Uint32(header[def_headerSize:]); got != want {
+		t.Fatalf("packet size mismatch: got %d, want %d", got, want)
+	}
+}
+
+func TestPacketHeaderPreservesLegacyEncoding(t *testing.T) {
+	want := uint32(10 * 1024 * 1024)
+	header := encodePacketHeader(want)
+	if len(header) != def_headerSize {
+		t.Fatalf("legacy header size mismatch: got %d, want %d", len(header), def_headerSize)
+	}
+
+	got, extended, ok := decodePacketHeader(header)
+	if !ok || extended {
+		t.Fatal("legacy packet header was not recognized")
+	}
+	if got != want {
+		t.Fatalf("packet size mismatch: got %d, want %d", got, want)
+	}
+}
+
+func TestPacketHeaderRejectsInvalidInput(t *testing.T) {
+	tests := [][]byte{
+		nil,
+		make([]byte, def_headerSize-1),
+		make([]byte, def_headerSize),
+	}
+	for _, header := range tests {
+		if _, _, ok := decodePacketHeader(header); ok {
+			t.Fatalf("invalid header accepted: %x", header)
+		}
+	}
+}


### PR DESCRIPTION
### Motivation
- Allow transmission and proposal of much larger transaction blocks and higher tx pool throughput to accommodate large-scale deployment and bulk proposals. 
- Preserve legacy KCP wire format while enabling an extended 32-bit length encoding for very large packets. 
- Increase internal scanning and block-selection limits to drain larger pending backlogs more effectively.

### Description
- Increased tx candidate scan limits in `core/tx_pool.go` by raising `fastPendingCandidateScanLimit` to `131072` and `slowPendingCandidateScanLimit` to `65536`.
- Raised protocol message maximum in `eth/protocol.go` by setting `protocolMaxMsgSize` to `257 * 1024 * 1024`.
- Adjusted tx/block sizing and quotas in `reconfig/txblock.go`, including bumping `fastBlockMaxTxCount` and `slowBlockMaxTxCount`, increasing `fastTxBlockProposalMaxBytes` to `128 * 1024 * 1024` and `slowTxBlockProposalMaxBytes` to `256 * 1024 * 1024`, and making `dexBlockMaxTxCount` equal to `slowBlockMaxTxCount`.
- Implemented extended KCP packet framing in `rnet/network/kcp.go` by adding an optional 32-bit extended length after the existing 24-bit size+magic header, with helper functions `encodePacketHeader` and `decodePacketHeader`, and updated `receiveRaw`/`sendRaw` to handle legacy and extended headers and to reject oversized packets.
- Added unit tests `rnet/network/kcp_test.go` that validate extended header encoding/decoding, legacy encoding preservation, and invalid header rejection using `encodePacketHeader` and `decodePacketHeader`.

### Testing
- Ran unit tests for the KCP network package with `go test ./rnet/network`, and the new header tests passed.
- Verified the KCP header encode/decode round-trip behavior via the added tests, which all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a287b4720f8833081fcf07f5c456095)